### PR TITLE
Incorrect parameters name in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,9 +115,9 @@ This is the easiest way to get started if you're using Home Assistant.
    ```yaml
    wifi_ssid: "YourWiFiSSID"
    wifi_password: "YourWiFiPassword"
-   deye_inverter_api_key: "your-32-character-api-key"
-   deye_inverter_ota_password: "your-ota-password"
-   deye_inverter_fallback_password: "your-fallback-password"
+   pv_inverter_api_key: "your-32-character-api-key"
+   pv_inverter_ota_password: "your-ota-password"
+   pv_inverter_fallback_password: "your-fallback-password"
    ```
 2. Click **"EDIT"** on your newly created device
 3. **Replace the entire content** with the configuration from [`pv-inverter.yaml`](pv-inverter.yaml)


### PR DESCRIPTION
Change parameters: deye_inverter_api_key, deye_inverter_ota_password, deye_inverter_fallback_password to it correct representation: pv_inverter_api_key, pv_inverter_ota_password, pv_inverter_fallback_password.