### PR TITLE
Fix/1p ac power scaling

### DIFF
--- a/pv_inverter/packages/deye_hybrid_1p/grid.yaml
+++ b/pv_inverter/packages/deye_hybrid_1p/grid.yaml
@@ -41,6 +41,7 @@ sensor:
     accuracy_decimals: 0
     entity_category: diagnostic
     icon: "mdi:multiplication"
+    internal: true
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}

--- a/pv_inverter/packages/deye_hybrid_1p/grid.yaml
+++ b/pv_inverter/packages/deye_hybrid_1p/grid.yaml
@@ -21,11 +21,27 @@ globals:
     restore_value: yes
 
 sensor:
+  # Register 54 = "AC power ratio" (1 or 10). Per the V119 protocol, the AC power
+  # registers 167-169, 170-172 and 176-178 are reported in units of this value (1W
+  # or 10W per LSB). Read it once and multiply those power sensors by it.
+  - platform: modbus_controller
+    modbus_controller_id: ${modbus_controller_id}
+    name: "AC Power Ratio"
+    id: ac_power_ratio
+    register_type: holding
+    address: 54
+    value_type: U_WORD
+    accuracy_decimals: 0
+    entity_category: diagnostic
+    icon: "mdi:multiplication"
+
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
     name: "Grid L1 Power"
     register_type: holding
     address: 167
+    filters:
+      - lambda: 'return std::isnan(id(ac_power_ratio).state) ? x : x * id(ac_power_ratio).state;'
     unit_of_measurement: "W"
     device_class: power
     state_class: "measurement"
@@ -38,6 +54,8 @@ sensor:
     name: "Grid L2 Power"
     register_type: holding
     address: 168
+    filters:
+      - lambda: 'return std::isnan(id(ac_power_ratio).state) ? x : x * id(ac_power_ratio).state;'
     unit_of_measurement: "W"
     device_class: power
     state_class: "measurement"
@@ -50,6 +68,8 @@ sensor:
     name: "Grid Power"
     register_type: holding
     address: 169
+    filters:
+      - lambda: 'return std::isnan(id(ac_power_ratio).state) ? x : x * id(ac_power_ratio).state;'
     unit_of_measurement: "W"
     device_class: power
     state_class: "measurement"
@@ -208,6 +228,8 @@ sensor:
     name: "External CT L1 Power"
     register_type: holding
     address: 170
+    filters:
+      - lambda: 'return std::isnan(id(ac_power_ratio).state) ? x : x * id(ac_power_ratio).state;'
     unit_of_measurement: "W"
     device_class: power
     accuracy_decimals: 0
@@ -219,6 +241,8 @@ sensor:
     name: "External CT L2 Power"
     register_type: holding
     address: 171
+    filters:
+      - lambda: 'return std::isnan(id(ac_power_ratio).state) ? x : x * id(ac_power_ratio).state;'
     unit_of_measurement: "W"
     device_class: power
     accuracy_decimals: 0
@@ -230,6 +254,8 @@ sensor:
     name: "External CT Power"
     register_type: holding
     address: 172
+    filters:
+      - lambda: 'return std::isnan(id(ac_power_ratio).state) ? x : x * id(ac_power_ratio).state;'
     unit_of_measurement: "W"
     device_class: power
     accuracy_decimals: 0

--- a/pv_inverter/packages/deye_hybrid_1p/grid.yaml
+++ b/pv_inverter/packages/deye_hybrid_1p/grid.yaml
@@ -12,6 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+substitutions:
+  # Register 54 = "AC power ratio". Only scale when it reads a known 10W/LSB
+  # value; pass raw watts through otherwise (covers 1, 0/unsupported and the
+  # not-yet-read NaN state).
+  func_scale_ac_power: "return (id(ac_power_ratio).state == 10.0f) ? x * 10.0f : x;"
+
 globals:
   - id: last_total_energy_bought
     type: float
@@ -21,9 +27,10 @@ globals:
     restore_value: yes
 
 sensor:
-  # Register 54 = "AC power ratio" (1 or 10). Per the V119 protocol, the AC power
-  # registers 167-169, 170-172 and 176-178 are reported in units of this value (1W
-  # or 10W per LSB). Read it once and multiply those power sensors by it.
+  # Register 54 = "AC power ratio". Per the V119 protocol, the AC power registers
+  # 167-169, 170-172 and 176-178 are reported in units of this value (1W or 10W
+  # per LSB). Verified on hardware: SG02 10kW reads 10 (10W units), SG04 6kW
+  # reads 0 (1W units) - so only a value of 10 triggers scaling.
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
     name: "AC Power Ratio"
@@ -41,7 +48,7 @@ sensor:
     register_type: holding
     address: 167
     filters:
-      - lambda: 'return std::isnan(id(ac_power_ratio).state) ? x : x * id(ac_power_ratio).state;'
+      - lambda: ${func_scale_ac_power}
     unit_of_measurement: "W"
     device_class: power
     state_class: "measurement"
@@ -55,7 +62,7 @@ sensor:
     register_type: holding
     address: 168
     filters:
-      - lambda: 'return std::isnan(id(ac_power_ratio).state) ? x : x * id(ac_power_ratio).state;'
+      - lambda: ${func_scale_ac_power}
     unit_of_measurement: "W"
     device_class: power
     state_class: "measurement"
@@ -69,7 +76,7 @@ sensor:
     register_type: holding
     address: 169
     filters:
-      - lambda: 'return std::isnan(id(ac_power_ratio).state) ? x : x * id(ac_power_ratio).state;'
+      - lambda: ${func_scale_ac_power}
     unit_of_measurement: "W"
     device_class: power
     state_class: "measurement"
@@ -229,7 +236,7 @@ sensor:
     register_type: holding
     address: 170
     filters:
-      - lambda: 'return std::isnan(id(ac_power_ratio).state) ? x : x * id(ac_power_ratio).state;'
+      - lambda: ${func_scale_ac_power}
     unit_of_measurement: "W"
     device_class: power
     accuracy_decimals: 0
@@ -242,7 +249,7 @@ sensor:
     register_type: holding
     address: 171
     filters:
-      - lambda: 'return std::isnan(id(ac_power_ratio).state) ? x : x * id(ac_power_ratio).state;'
+      - lambda: ${func_scale_ac_power}
     unit_of_measurement: "W"
     device_class: power
     accuracy_decimals: 0
@@ -255,7 +262,7 @@ sensor:
     register_type: holding
     address: 172
     filters:
-      - lambda: 'return std::isnan(id(ac_power_ratio).state) ? x : x * id(ac_power_ratio).state;'
+      - lambda: ${func_scale_ac_power}
     unit_of_measurement: "W"
     device_class: power
     accuracy_decimals: 0

--- a/pv_inverter/packages/deye_hybrid_1p/load.yaml
+++ b/pv_inverter/packages/deye_hybrid_1p/load.yaml
@@ -43,6 +43,8 @@ sensor:
     name: "Load L1 Power"
     register_type: holding
     address: 176
+    filters:
+      - lambda: 'return std::isnan(id(ac_power_ratio).state) ? x : x * id(ac_power_ratio).state;'
     unit_of_measurement: "W"
     device_class: power
     state_class: "measurement"
@@ -55,6 +57,8 @@ sensor:
     name: "Load L2 Power"
     register_type: holding
     address: 177
+    filters:
+      - lambda: 'return std::isnan(id(ac_power_ratio).state) ? x : x * id(ac_power_ratio).state;'
     unit_of_measurement: "W"
     device_class: power
     state_class: "measurement"
@@ -67,6 +71,8 @@ sensor:
     name: "Load Power"
     register_type: holding
     address: 178
+    filters:
+      - lambda: 'return std::isnan(id(ac_power_ratio).state) ? x : x * id(ac_power_ratio).state;'
     unit_of_measurement: "W"
     device_class: power
     state_class: "measurement"

--- a/pv_inverter/packages/deye_hybrid_1p/load.yaml
+++ b/pv_inverter/packages/deye_hybrid_1p/load.yaml
@@ -11,6 +11,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+substitutions:
+  # Register 54 = "AC power ratio" (defined in grid.yaml). Only scale when it
+  # reads a known 10W/LSB value; pass raw watts through otherwise (covers 1,
+  # 0/unsupported and the not-yet-read NaN state).
+  func_scale_ac_power: "return (id(ac_power_ratio).state == 10.0f) ? x * 10.0f : x;"
+
 sensor:
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
@@ -44,7 +51,7 @@ sensor:
     register_type: holding
     address: 176
     filters:
-      - lambda: 'return std::isnan(id(ac_power_ratio).state) ? x : x * id(ac_power_ratio).state;'
+      - lambda: ${func_scale_ac_power}
     unit_of_measurement: "W"
     device_class: power
     state_class: "measurement"
@@ -58,7 +65,7 @@ sensor:
     register_type: holding
     address: 177
     filters:
-      - lambda: 'return std::isnan(id(ac_power_ratio).state) ? x : x * id(ac_power_ratio).state;'
+      - lambda: ${func_scale_ac_power}
     unit_of_measurement: "W"
     device_class: power
     state_class: "measurement"
@@ -72,7 +79,7 @@ sensor:
     register_type: holding
     address: 178
     filters:
-      - lambda: 'return std::isnan(id(ac_power_ratio).state) ? x : x * id(ac_power_ratio).state;'
+      - lambda: ${func_scale_ac_power}
     unit_of_measurement: "W"
     device_class: power
     state_class: "measurement"


### PR DESCRIPTION
## Description

Fixes incorrect AC power readings on the single-phase (1P) integration.

On inverters where the "AC power ratio" register (register 54) is set to 10, the inverter reports all AC power values in 10 W units instead of 1 W. The integration read these registers as raw watts, so every AC power sensor was 10× too low — e.g. External CT Power showed 875 W while the inverter's own screen showed 8750 W.

Per the V119 Modbus protocol, register 54 (ACpowerratio, value 1 or 10) sets the unit (1 W or 10 W per LSB) for power registers 167,168,169,170,171,172,176,177,178. This PR reads register 54 and multiplies those sensors by it.

## Changes relate to

<!-- Please select what this PR relates to (select one or more): -->
- [ ] Docs
- [ ] Deye 3P LP
- [ ] Deye 3P HV
- [X] Deye 1P LP
- [ ] Other

## Changes

New diagnostic sensor "AC Power Ratio" (register 54).
Multiply the affected 1P power sensors by that ratio (filter falls back to the raw value until the ratio is first read):
Grid L1 / L2 / Total Power (167 / 168 / 169) — grid.yaml
External CT L1 / L2 / Total Power (170 / 171 / 172) — grid.yaml
Load L1 / L2 / Total Power (176 / 177 / 178) — load.yaml
Added the Deye 1P V119 Modbus protocol document under docs/modbus_communication_protocols/ as the source for this behaviour.

# Notes

Backward compatible: inverters with register 54 = 1 multiply by 1 (no change).
Registers not flagged as 10 W in the protocol (inverter output power 173–175, battery power 190, etc.) are intentionally left unscaled.
1P only 

# How it was verified

Hardware with register 54 = 10: 
External CT Power now reads 8750 W, matching the inverter display (esphome was saying 875 W before); the other Grid/Load power sensors scale accordingly.
The new AC Power Ratio entity reads 10 (or 1), so the applied factor is visible.