### PR TITLE
feat(1P): add Time of Use Sell Mode switches (registers 274-279, bit 6)

### DIFF
--- a/pv_inverter/packages/deye_hybrid_1p/tou.yaml
+++ b/pv_inverter/packages/deye_hybrid_1p/tou.yaml
@@ -100,6 +100,7 @@ switch:
     modbus_controller_id: ${modbus_controller_id}
     name: "Time of Use 1 Charge Enable"
     id: switch_time_point_1_charge_enable
+    restore_mode: DISABLED
     register_type: holding
     address: 274
     bitmask: 1
@@ -110,6 +111,7 @@ switch:
     modbus_controller_id: ${modbus_controller_id}
     name: "Time of Use 2 Charge Enable"
     id: switch_time_point_2_charge_enable
+    restore_mode: DISABLED
     register_type: holding
     address: 275
     bitmask: 1
@@ -120,6 +122,7 @@ switch:
     modbus_controller_id: ${modbus_controller_id}
     name: "Time of Use 3 Charge Enable"
     id: switch_time_point_3_charge_enable
+    restore_mode: DISABLED
     register_type: holding
     address: 276
     bitmask: 1
@@ -130,6 +133,7 @@ switch:
     modbus_controller_id: ${modbus_controller_id}
     name: "Time of Use 4 Charge Enable"
     id: switch_time_point_4_charge_enable
+    restore_mode: DISABLED
     register_type: holding
     address: 277
     bitmask: 1
@@ -140,6 +144,7 @@ switch:
     modbus_controller_id: ${modbus_controller_id}
     name: "Time of Use 5 Charge Enable"
     id: switch_time_point_5_charge_enable
+    restore_mode: DISABLED
     register_type: holding
     address: 278
     bitmask: 1
@@ -150,10 +155,85 @@ switch:
     modbus_controller_id: ${modbus_controller_id}
     name: "Time of Use 6 Charge Enable"
     id: switch_time_point_6_charge_enable
+    restore_mode: DISABLED
     register_type: holding
     address: 279
     bitmask: 1
     icon: "mdi:battery-plus"
+
+  # Sell Mode = undocumented bit 6 (0x40) of the per-slot control registers 274-279.
+  # Native modbus_controller bitmask switch. Writing a bitmask switch blind-writes
+  # (state ? bitmask : 0), so toggling Sell clears the other bits (incl. grid-charge
+  # bit0) and vice-versa -> buy and sell are mutually exclusive per slot.
+  # restore_mode: DISABLED is REQUIRED here (and on the Charge Enable switches above):
+  # a modbus switch otherwise writes its restored state on boot, and because the write
+  # clobbers the whole register that boot-write would wipe grid-charge/sell on every
+  # flash. DISABLED = read-only on boot, write only on user toggle.
+  - platform: modbus_controller
+    use_write_multiple: true
+    modbus_controller_id: ${modbus_controller_id}
+    name: "Time of Use 1 Sell Mode"
+    id: switch_time_point_1_sell_mode
+    restore_mode: DISABLED
+    register_type: holding
+    address: 274
+    bitmask: 64
+    icon: "mdi:transmission-tower-export"
+
+  - platform: modbus_controller
+    use_write_multiple: true
+    modbus_controller_id: ${modbus_controller_id}
+    name: "Time of Use 2 Sell Mode"
+    id: switch_time_point_2_sell_mode
+    restore_mode: DISABLED
+    register_type: holding
+    address: 275
+    bitmask: 64
+    icon: "mdi:transmission-tower-export"
+
+  - platform: modbus_controller
+    use_write_multiple: true
+    modbus_controller_id: ${modbus_controller_id}
+    name: "Time of Use 3 Sell Mode"
+    id: switch_time_point_3_sell_mode
+    restore_mode: DISABLED
+    register_type: holding
+    address: 276
+    bitmask: 64
+    icon: "mdi:transmission-tower-export"
+
+  - platform: modbus_controller
+    use_write_multiple: true
+    modbus_controller_id: ${modbus_controller_id}
+    name: "Time of Use 4 Sell Mode"
+    id: switch_time_point_4_sell_mode
+    restore_mode: DISABLED
+    register_type: holding
+    address: 277
+    bitmask: 64
+    icon: "mdi:transmission-tower-export"
+
+  - platform: modbus_controller
+    use_write_multiple: true
+    modbus_controller_id: ${modbus_controller_id}
+    name: "Time of Use 5 Sell Mode"
+    id: switch_time_point_5_sell_mode
+    restore_mode: DISABLED
+    register_type: holding
+    address: 278
+    bitmask: 64
+    icon: "mdi:transmission-tower-export"
+
+  - platform: modbus_controller
+    use_write_multiple: true
+    modbus_controller_id: ${modbus_controller_id}
+    name: "Time of Use 6 Sell Mode"
+    id: switch_time_point_6_sell_mode
+    restore_mode: DISABLED
+    register_type: holding
+    address: 279
+    bitmask: 64
+    icon: "mdi:transmission-tower-export"
 
   - platform: template
     name: "Time of Use All Charge Enable"


### PR DESCRIPTION
## Description

Adds six "Time of Use N Sell Mode" switches for the single-phase inverter, toggling the undocumented bit 6 (0x40) of the per-slot Time-of-Use control registers 274-279 (hardware-validated; not in the V119 protocol). Implemented as native modbus_controller bitmask switches, mirroring the existing Charge Enable switches (bit 0); grid-charge (buy) and sell are mutually exclusive per slot.

Also sets restore_mode: DISABLED on the Sell Mode and Charge Enable switches so they no longer write registers 274-279 on boot: a modbus switch re-asserts its restored state during setup(), and a bitmask write clobbers the whole register, which wiped grid-charge/sell settings on every flash.

## Changes relate to

<!-- Please select what this PR relates to (select one or more): -->
- [ ] Docs
- [ ] Deye 3P LP
- [ ] Deye 3P HV
- [X] Deye 1P LP
- [ ] Other

## Changes

Added six switches "Time of Use 1–6 Sell Mode" to the single-phase package — native modbus_controller bitmask switches on bit 6 (0x40) of registers 274–279, one per Time-of-Use slot, mirroring the existing "Charge Enable" switches (bit 0).
Added restore_mode: DISABLED to the new Sell Mode switches and the existing Charge Enable switches on registers 274–279.

## Notes

Undocumented bit: bit 6 isn't in the 2025 V119 modbus protocol, but is hardware-validated — enabling "sell" for a time point on the inverter's own screen sets it (e.g. register 277 reads 0x0040 with sell enabled for slot 4) See image below. 
Buy/sell are mutually exclusive per slot: a bitmask-switch write sets its own bit and clears the rest of the register, so enabling Sell clears grid-charge (bit 0) and vice-versa.
restore_mode: DISABLED is required: a modbus_controller switch otherwise re-asserts its restored state during setup(), and because a bitmask write overwrites the whole 16-bit register, that boot-write wiped the slot's grid-charge/sell bits on every flash. DISABLED makes these switches read-only on boot (state still comes from polling; writes happen only on user toggle). This also hardens the existing Charge Enable switches against the same boot-clobber.
Trade-off (identical to how Charge Enable already behaves): toggling a switch clears the other mode bits in that register at write time.
1P only — the 3P package is untouched.

## How it was verified

Flashed to hardware: toggling Time of Use - Sell Mode sets/clears bit 6 (0x0040) of the matching register (274–279), cross-checked against the inverter's own Sell Mode setting for that slot.
Confirmed mutual exclusion: enabling Sell clears that slot's grid-charge bit, and enabling Charge Enable clears the sell bit.
Confirmed the boot fix: with restore_mode: DISABLED, grid-charge and sell settings now survive a flash (previously they were reset to 0 on every flash).

## New Sell Mode inside system work mode 

<img width="422" height="555" alt="image" src="https://github.com/user-attachments/assets/719c3dfb-b67e-46ae-a8bf-0c295d17a758" />


## Inverter Firmware Version

<img width="1002" height="737" alt="image" src="https://github.com/user-attachments/assets/898a6e17-6dc0-4ae6-9aad-c89785fcf164" />
