### PR TITLE
fix(1P): correct Battery Current scale from 0.01A to 0.1A (register 191)

### DIFF
--- a/pv_inverter/packages/deye_hybrid_1p/battery.yaml
+++ b/pv_inverter/packages/deye_hybrid_1p/battery.yaml
@@ -135,7 +135,7 @@ sensor:
     device_class: current
     accuracy_decimals: 2
     filters:
-      - multiply: 0.01
+      - multiply: 0.1
     value_type: S_WORD
     icon: "mdi:current-dc"
 


### PR DESCRIPTION
## Description

Fixes the scaling of the Battery Current sensor (register 191) for single-phase
hybrid inverters. Fixes #127.

The sensor was applying a `multiply: 0.01` filter, but register 191 reports
battery current with a resolution of 0.1 A per LSB, so the reported current was
10x lower than the actual value.

As shown in #127, comparing battery current from inverter screen vs the inverter's
Modbus data: 
Battery Power agreed perfectly between the two, but Battery Current
was exactly 10x too low. Since power was correct, only the current scale factor
was wrong. With `multiply: 0.1` the current matches the BMS reading and is
consistent with Power = Voltage × Current.

## Changes relate to

<!-- Please select what this PR relates to (select one or more): -->
- [ ] Docs
- [ ] Deye 3P LP
- [ ] Deye 3P HV
- [X] Deye 1P LP
- [ ] Other
