### PR TITLE
Revert #117: "Force Grid Charge Start SOC" collides with Grid Peak Shaving Power on register 191

### DIFF
--- a/pv_inverter/packages/deye_hybrid_3p/battery.yaml
+++ b/pv_inverter/packages/deye_hybrid_3p/battery.yaml
@@ -817,16 +817,3 @@ number:
     value_type: U_WORD
     mode: box
     icon: "mdi:battery-charging-50"
-
-  - platform: modbus_controller
-    modbus_controller_id: ${modbus_controller_id} 
-    name: "Force Grid Charge Start SOC"
-    register_type: holding
-    address: 191
-    value_type: U_WORD
-    unit_of_measurement: "%"
-    icon: "mdi:battery-charging-high"
-    entity_category: config
-    min_value: 0
-    max_value: 100
-    step: 1


### PR DESCRIPTION
PR #117 added a `Force Grid Charge Start SOC` number entity in `deye_hybrid_3p/battery.yaml` pointing at **holding register 191**.

Register 191 on the Deye 3-phase map is **Grid Peak Shaving power**, and it is already exposed as `Grid Peak Shaving Power` in `deye_hybrid_3p/work_mode.yaml`. Two RW `number` entities now write to the same register:

- `battery.yaml` → `Force Grid Charge Start SOC` (%, register 191) — added by #117
- `work_mode.yaml` → `Grid Peak Shaving Power` (W, register 191)

They clash: writing the SOC control overwrites the peak-shaving setpoint (and vice-versa), and the value is interpreted with the wrong unit/scale.

Cross-checked against the Sunsynk register reference (`three_phase_common.py`), which maps 191 to *Grid Peak Shaving power* only. The grid-charge start SOC is a separate register — 127 — already exposed as `Battery Grid Charging Start SOC`.

This reverts commit 6ec1151b99cf926fc233521c2a8073450676a5d5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019HXonfmKDbxqu9u2xB9524