### PR TITLE
Implemented multiple modbus-connections, tested for pv-inverter.Deye-SG0XLP1. Added prefix and nameprefix for seperating multiple instances, added example implementations.

### DIFF
--- a/devices/Waveshare-ESP32-S3-RS485-CAN/Deye-SG0xLP1.yaml
+++ b/devices/Waveshare-ESP32-S3-RS485-CAN/Deye-SG0xLP1.yaml
@@ -38,13 +38,6 @@ esphome:
   min_version: "2025.6.0"
   name_add_mac_suffix: true
 
-uart:
-  tx_pin: GPIO17
-  rx_pin: GPIO18
-
-modbus:
-  flow_control_pin: GPIO21
-
 logger:
   level: WARN # VERBOSE / DEBUG / INFO / WARN
 

--- a/pv-inverter.Deye-SG0XLP1-multi.yaml
+++ b/pv-inverter.Deye-SG0XLP1-multi.yaml
@@ -63,11 +63,6 @@ esp32:
   framework:
     type: esp-idf
 
-uart:
-  # Default TX and RX pins, if TTL converter is connected differently, set appropriate pins
-  tx_pin: GPIO17
-  rx_pin: GPIO16
-
 modbus:
 #  flow_control_pin: GPIO4 # Uncomment and set appropriate pin if your TTL converter requires it
 

--- a/pv-inverter.Deye-SG0XLP1-multi.yaml
+++ b/pv-inverter.Deye-SG0XLP1-multi.yaml
@@ -41,6 +41,8 @@ substitutions:
   baud_rate: "9600"
   update_interval: "30s"
 
+  pv_inverter_api_key: "" 
+
 packages:
   inverter_logic:
     # 1. Die Quelle bleibt das Git-Repository (jetzt zeigt es auf DEINEN Fork)

--- a/pv-inverter.Deye-SG0XLP1-multi.yaml
+++ b/pv-inverter.Deye-SG0XLP1-multi.yaml
@@ -19,8 +19,6 @@ substitutions:
   ota_password: !secret pv_inverter_ota_password
   fallback_password: !secret pv_inverter_fallback_password
 
-  modbus_inverter_address: "0x01" # Default Modbus address, should be changed to match inverter settings
-
   # Safe Mode parameters for supported inverters
   safe_mode_delay: 600s # Time after which transition to safe mode and setting default operating parameters will occur
   default_maximum_battery_charge_current: "130" # Amps

--- a/pv-inverter.Deye-SG0XLP1-multi.yaml
+++ b/pv-inverter.Deye-SG0XLP1-multi.yaml
@@ -55,7 +55,7 @@ packages:
           modbus_inverter_address: ${modbus_inverter_address}
           modbus_hub_id: ${modbus_hub_id}
           uart_hub_id: ${uart_hub_id}
-          prefix: "123" #${prefix}
+          prefix: ${prefix}
 
 # Set appropriately if using a different board. https://esphome.io/components/#supported-microcontrollers
 esp32:

--- a/pv-inverter.Deye-SG0XLP1-multi.yaml
+++ b/pv-inverter.Deye-SG0XLP1-multi.yaml
@@ -63,8 +63,5 @@ esp32:
   framework:
     type: esp-idf
 
-modbus:
-#  flow_control_pin: GPIO4 # Uncomment and set appropriate pin if your TTL converter requires it
-
 #logger:
 #  level: VERBOSE # VERBOSE / DEBUG / INFO / WARN

--- a/pv-inverter.Deye-SG0XLP1-multi.yaml
+++ b/pv-inverter.Deye-SG0XLP1-multi.yaml
@@ -55,7 +55,7 @@ packages:
           modbus_inverter_address: ${modbus_inverter_address}
           modbus_hub_id: ${modbus_hub_id}
           uart_hub_id: ${uart_hub_id}
-          prefix: ${prefix}
+          prefix: "123" #${prefix}
 
 # Set appropriately if using a different board. https://esphome.io/components/#supported-microcontrollers
 esp32:

--- a/pv-inverter.Deye-SG0XLP1-multi.yaml
+++ b/pv-inverter.Deye-SG0XLP1-multi.yaml
@@ -43,11 +43,9 @@ substitutions:
 
 packages:
   inverter_logic:
-    # 1. Die Quelle bleibt das Git-Repository (jetzt zeigt es auf DEINEN Fork)
-    url: https://github.com
+    url: https://github.com/JHopmann/esphome-deye-inverter
     refresh: 12h
     
-    # 2. Unter "files:" rufen wir die Datei auf und füttern sie mit den Variablen
     files:
       - path: pv_inverter/deye_hybrid_1p_lv.yaml
         vars:

--- a/pv-inverter.Deye-SG0XLP1-multi.yaml
+++ b/pv-inverter.Deye-SG0XLP1-multi.yaml
@@ -44,7 +44,7 @@ substitutions:
 packages:
   inverter_logic:
     url: https://github.com/JHopmann/esphome-deye-inverter
-    refresh: 12h
+    refresh: 0s
     
     files:
       - path: pv_inverter/deye_hybrid_1p_lv.yaml

--- a/pv-inverter.Deye-SG0XLP1-multi.yaml
+++ b/pv-inverter.Deye-SG0XLP1-multi.yaml
@@ -1,0 +1,77 @@
+# Copyright 2025 Lewa-Reka <lewareka.yt@gmail.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+substitutions:
+  wifi_ssid: !secret wifi_ssid
+  wifi_password: !secret wifi_password
+  api_key: !secret pv_inverter_api_key
+  ota_password: !secret pv_inverter_ota_password
+  fallback_password: !secret pv_inverter_fallback_password
+
+  modbus_inverter_address: "0x01" # Default Modbus address, should be changed to match inverter settings
+
+  # Safe Mode parameters for supported inverters
+  safe_mode_delay: 600s # Time after which transition to safe mode and setting default operating parameters will occur
+  default_maximum_battery_charge_current: "130" # Amps
+  default_max_sell_power: "6000" # Watts. Adjust to your inverter
+  default_system_work_mode: "Zero Export To Load" # "Selling First", "Zero Export To Load", "Zero Export To CT"
+  default_solar_sell: "on" # "on", "off"
+
+  # Defaults, in case sthg missing:
+  name: "deye-inverter"
+  friendly_name: "Deye Inverter"
+  modbus_controller_id: "deye_modbus_controller"
+  modbus_inverter_address: "0x01"
+  modbus_hub_id: "modbus_1"
+  uart_hub_id: "modbus_uart_1"
+  prefix: ""
+  
+  # Global Defaults
+  baud_rate: "9600"
+  update_interval: "30s"
+
+packages:
+  inverter_logic:
+    # 1. Die Quelle bleibt das Git-Repository (jetzt zeigt es auf DEINEN Fork)
+    url: https://github.com
+    refresh: 12h
+    
+    # 2. Unter "files:" rufen wir die Datei auf und füttern sie mit den Variablen
+    files:
+      - path: pv_inverter/deye_hybrid_1p_lv.yaml
+        vars:
+          name: ${name}
+          friendly_name: ${friendly_name}
+          modbus_controller_id: ${modbus_controller_id}
+          modbus_inverter_address: ${modbus_inverter_address}
+          modbus_hub_id: ${modbus_hub_id}
+          uart_hub_id: ${uart_hub_id}
+          prefix: ${prefix}
+
+# Set appropriately if using a different board. https://esphome.io/components/#supported-microcontrollers
+esp32:
+  board: esp32dev
+  framework:
+    type: esp-idf
+
+uart:
+  # Default TX and RX pins, if TTL converter is connected differently, set appropriate pins
+  tx_pin: GPIO17
+  rx_pin: GPIO16
+
+modbus:
+#  flow_control_pin: GPIO4 # Uncomment and set appropriate pin if your TTL converter requires it
+
+#logger:
+#  level: VERBOSE # VERBOSE / DEBUG / INFO / WARN

--- a/pv-inverter.Deye-SG0XLP1.yaml
+++ b/pv-inverter.Deye-SG0XLP1.yaml
@@ -19,8 +19,6 @@ substitutions:
   ota_password: !secret pv_inverter_ota_password
   fallback_password: !secret pv_inverter_fallback_password
 
-  modbus_inverter_address: "0x01" # Default Modbus address, should be changed to match inverter settings
-
   # Safe Mode parameters for supported inverters
   safe_mode_delay: 600s # Time after which transition to safe mode and setting default operating parameters will occur
   default_maximum_battery_charge_current: "130" # Amps
@@ -28,25 +26,42 @@ substitutions:
   default_system_work_mode: "Zero Export To Load" # "Selling First", "Zero Export To Load", "Zero Export To CT"
   default_solar_sell: "on" # "on", "off"
 
+  # Defaults, in case sthg missing:
+  name: "deye-inverter"
+  friendly_name: "Deye Inverter"
+  modbus_controller_id: "deye_modbus_controller"
+  modbus_inverter_address: "0x01"
+  modbus_hub_id: "modbus_1"
+  uart_hub_id: "modbus_uart_1"
+  prefix: ""
+  
+  # Global Defaults
+  baud_rate: "9600"
+  update_interval: "30s"
+
+  pv_inverter_api_key: "" 
+
 packages:
-  pv_inverter:
-    url: https://github.com/Lewa-Reka/esphome-deye-inverter
-    refresh: 12h
-    files: pv_inverter/deye_hybrid_1p_lv.yaml # SG0XLP1 Low Voltage (1P)
+  inverter_logic:
+    url: https://github.com/JHopmann/esphome-deye-inverter
+    refresh: 0s
+    
+    files:
+      - path: pv_inverter/deye_hybrid_1p_lv.yaml
+        vars:
+          name: ${name}
+          friendly_name: ${friendly_name}
+          modbus_controller_id: ${modbus_controller_id}
+          modbus_inverter_address: ${modbus_inverter_address}
+          modbus_hub_id: ${modbus_hub_id}
+          uart_hub_id: ${uart_hub_id}
+          prefix: ${prefix}
 
 # Set appropriately if using a different board. https://esphome.io/components/#supported-microcontrollers
 esp32:
   board: esp32dev
   framework:
     type: esp-idf
-
-uart:
-  # Default TX and RX pins, if TTL converter is connected differently, set appropriate pins
-  tx_pin: GPIO17
-  rx_pin: GPIO16
-
-modbus:
-#  flow_control_pin: GPIO4 # Uncomment and set appropriate pin if your TTL converter requires it
 
 #logger:
 #  level: VERBOSE # VERBOSE / DEBUG / INFO / WARN

--- a/pv-inverter.yaml
+++ b/pv-inverter.yaml
@@ -18,7 +18,7 @@ substitutions:
   api_key: !secret pv_inverter_api_key
   ota_password: !secret pv_inverter_ota_password
   fallback_password: !secret pv_inverter_fallback_password
-
+  
   modbus_inverter_address: "0x01" # Default Modbus address, should be changed to match inverter settings
 
   # Safe Mode parameters for supported inverters
@@ -28,24 +28,83 @@ substitutions:
   default_system_work_mode: "Zero Export To Load" # "Selling First", "Zero Export To Load", "Zero Export To CT"
   default_solar_sell: "on" # "on", "off"
   default_force_off_grid: "off" # "on", "off"
-
+  
   enable_sync_time: false # true, false - Enable time sync with HomeAssistant (Deye 3P inverters only)
 
+###########################################
+# ============ PACKAGES ================= #
+# Comment/uncomment the part you need,    #
+# depending wether you have connected     #
+# one or multiple inverters to your ESP   #
+###########################################
+
 packages:
-  pv_inverter:
-    url: https://github.com/Lewa-Reka/esphome-deye-inverter
+  
+#  deye_master:
+#    refresh: 12h
+#    files:
+#      - path: pv-inverter.Deye-SG0XLP1.yaml
+#        vars:
+#          name: "deye-master"
+#          friendly_name: "Deye Master"
+#          modbus_controller_id: "deye_master"
+#          modbus_hub_id_1: "modbus_1"
+#          uart_hub_id_1: "modbus_uart_1"
+#          modbus_hub_id_2: "modbus_2"
+#          uart_hub_id_2: "modbus_uart_2"
+#          prefix: "master_"
+#          nameprefix: "Master "
+#      - path: pv_inverter/packages/deye_hybrid_1p/modbus_master.yaml
+#        vars:
+#          # Hier steuerst du deine Pins für den Slave-Bus:
+#          uart_tx_pin_master: "GPIO26"
+#          uart_rx_pin_master: "GPIO35"
+#          uart_tx_pin_slave: "GPIO17"
+#          uart_rx_pin_slave: "GPIO04"
+#          uart_flow_control_pin_master: "GPIO25"
+#          uart_flow_control_pin_slave: "GPIO16"
+#  # 2. SLAVE-INVERTER
+#  deye_slave:
+#    refresh: 12h
+#    files:
+#      - path: pv-inverter.Deye-SG0XLP1.yaml
+#        vars:
+#          name: "deye-slave"
+#          friendly_name: "Deye Slave"
+#          modbus_controller_id: "deye_slave_controller"
+#          prefix: "slave_"
+#          nameprefix: "Slave "
+#      - path: pv_inverter/packages/deye_hybrid_1p/modbus_slave.yaml
+#
+
+  # 1. SINGLE-INVERTER
+  deye_slave:
     refresh: 12h
     files:
-      ### Use the appropriate file for your inverter, uncomment the one you want to use ###
-      # pv_inverter/deye_hybrid_1p_lv.yaml # SG0XLP1 Low Voltage (1P)
-      pv_inverter/deye_hybrid_3p_lv.yaml # SG0XLP3 Low Voltage (3P)
-      # pv_inverter/deye_hybrid_3p_hv.yaml # SG0XHP3 High Voltage (3P)
+      - path: pv-inverter.Deye-SG0XLP1.yaml
+        vars:
+          name: "deye-inverter"
+          friendly_name: "Deye Inverter"
+          modbus_controller_id: "deye_controller"
+          modbus_hub_id_1: "modbus_1"
+          uart_hub_id_1: "modbus_uart_1"
+          modbus_hub_id_2: "modbus_2"
+          uart_hub_id_2: "modbus_uart_2"
+          prefix: ""
+          nameprefix: ""
+      - path: pv_inverter/packages/deye_hybrid_1p/modbus_master.yaml
+        vars:
+          # Hier steuerst du deine Pins für den Slave-Bus:
+          uart_tx_pin_master: "GPIO26"
+          uart_rx_pin_master: "GPIO35"
+          uart_flow_control_pin_master: "GPIO25"
 
 # Set appropriately if using a different board. https://esphome.io/components/#supported-microcontrollers
 esp32:
   board: esp32dev
   framework:
     type: esp-idf
+
 
 #logger:
 #  level: VERBOSE # VERBOSE / DEBUG / INFO / WARN

--- a/pv-inverter.yaml
+++ b/pv-inverter.yaml
@@ -47,13 +47,5 @@ esp32:
   framework:
     type: esp-idf
 
-uart:
-  # Default TX and RX pins, if TTL converter is connected differently, set appropriate pins
-  tx_pin: GPIO17
-  rx_pin: GPIO16
-
-modbus:
-#  flow_control_pin: GPIO4 # Uncomment and set appropriate pin if your TTL converter requires it
-
 #logger:
 #  level: VERBOSE # VERBOSE / DEBUG / INFO / WARN

--- a/pv_inverter/deye_hybrid_1p_lv.yaml
+++ b/pv_inverter/deye_hybrid_1p_lv.yaml
@@ -1,15 +1,8 @@
 substitutions:
-  # Das sind die Standardwerte (Defaults), hauptsächlich für den Master:
-  name: "deye-inverter"
+  name: deye-inverter
   friendly_name: "Deye Inverter"
   device_description: "Deye Inverter SG0XLP1"
-  modbus_controller_id: "deye_modbus_controller"
-  
-  # Hier reichen wir die Variablen weiter, die wir vorhin besprochen haben:
-  prefix: ""
-  modbus_hub_id: "modbus_1"
-  uart_hub_id: "modbus_uart_1"
-  modbus_inverter_address: "0x01"
+  modbus_controller_id: deye_modbus_controller
   baud_rate: "9600"
   # Safe Mode Default parameters
   default_maximum_battery_charge_current: "130" # Amps

--- a/pv_inverter/deye_hybrid_1p_lv.yaml
+++ b/pv_inverter/deye_hybrid_1p_lv.yaml
@@ -1,8 +1,15 @@
 substitutions:
-  name: deye-inverter
+  # Das sind die Standardwerte (Defaults), hauptsächlich für den Master:
+  name: "deye-inverter"
   friendly_name: "Deye Inverter"
   device_description: "Deye Inverter SG0XLP1"
-  modbus_controller_id: deye_modbus_controller
+  modbus_controller_id: "deye_modbus_controller"
+  
+  # Hier reichen wir die Variablen weiter, die wir vorhin besprochen haben:
+  prefix: ""
+  modbus_hub_id: "modbus_1"
+  uart_hub_id: "modbus_uart_1"
+  modbus_inverter_address: "0x01"
   baud_rate: "9600"
   # Safe Mode Default parameters
   default_maximum_battery_charge_current: "130" # Amps

--- a/pv_inverter/deye_hybrid_1p_lv.yaml
+++ b/pv_inverter/deye_hybrid_1p_lv.yaml
@@ -29,13 +29,13 @@ script:
           level: INFO
           format: "Setting safe Modbus register values"
       - number.set:
-          id: maximum_battery_charge_current
+          id: ${prefix}maximum_battery_charge_current
           value: ${default_maximum_battery_charge_current}
       - number.set:
-          id: max_sell_power
+          id: ${prefix}max_sell_power
           value: ${default_max_sell_power}
       - select.set:
-          id: system_work_mode
+          id: ${prefix}system_work_mode
           option: ${default_system_work_mode}
       - switch.turn_${default_solar_sell}:
-          id: switch_solar_sell
+          id: ${prefix}switch_solar_sell

--- a/pv_inverter/deye_hybrid_1p_lv.yaml
+++ b/pv_inverter/deye_hybrid_1p_lv.yaml
@@ -23,7 +23,7 @@ packages:
   tou: !include packages/deye_hybrid_1p/tou.yaml
 
 script:
-  - id: ${prefix}set_safe_modbus_registers
+  - id: set_safe_modbus_registers
     then:
       - logger.log:
           level: INFO

--- a/pv_inverter/deye_hybrid_1p_lv.yaml
+++ b/pv_inverter/deye_hybrid_1p_lv.yaml
@@ -23,7 +23,7 @@ packages:
   tou: !include packages/deye_hybrid_1p/tou.yaml
 
 script:
-  - id: set_safe_modbus_registers
+  - id: ${prefix}set_safe_modbus_registers
     then:
       - logger.log:
           level: INFO

--- a/pv_inverter/packages/deye_hybrid_1p/battery.yaml
+++ b/pv_inverter/packages/deye_hybrid_1p/battery.yaml
@@ -34,7 +34,7 @@ sensor:
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
     name: "${prefix}Daily Battery Discharge"
-    id: "${prefix}"${prefix}daily_battery_discharge"
+    id: "${prefix}daily_battery_discharge"
     register_type: holding
     address: 71
     unit_of_measurement: "kWh"

--- a/pv_inverter/packages/deye_hybrid_1p/battery.yaml
+++ b/pv_inverter/packages/deye_hybrid_1p/battery.yaml
@@ -12,11 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+substitutions:
+  prefix: ""
+
 sensor:
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "Daily Battery Charge"
-    id: daily_battery_charge
+    name: "${prefix}Daily Battery Charge"
+    id: "${prefix}daily_battery_charge"
     register_type: holding
     address: 70
     unit_of_measurement: "kWh"
@@ -30,8 +33,8 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "Daily Battery Discharge"
-    id: daily_battery_discharge
+    name: "${prefix}Daily Battery Discharge"
+    id: "${prefix}"${prefix}daily_battery_discharge"
     register_type: holding
     address: 71
     unit_of_measurement: "kWh"
@@ -45,8 +48,8 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "Total Battery Charge"
-    id: total_battery_charge
+    name: "${prefix}Total Battery Charge"
+    id: "${prefix}"${prefix}total_battery_charge"
     register_type: holding
     address: 72
     unit_of_measurement: "kWh"
@@ -60,8 +63,8 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "Total Battery Discharge"
-    id: total_battery_discharge
+    name: "${prefix}Total Battery Discharge"
+    id: "${prefix}"${prefix}total_battery_discharge"
     register_type: holding
     address: 74
     unit_of_measurement: "kWh"
@@ -75,7 +78,7 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "Battery Temperature"
+    name: "${prefix}Battery Temperature"
     register_type: holding
     address: 182
     unit_of_measurement: "°C"
@@ -89,8 +92,8 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "Battery Voltage"
-    id: battery_voltage
+    name: "${prefix}Battery Voltage"
+    id: "${prefix}battery_voltage"
     register_type: holding
     address: 183
     unit_of_measurement: "V"
@@ -103,7 +106,7 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "Battery"
+    name: "${prefix}Battery"
     register_type: holding
     address: 184
     unit_of_measurement: "%"
@@ -115,8 +118,8 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "Battery Power"
-    id: battery_power
+    name: "${prefix}Battery Power"
+    id: "${prefix}battery_power"
     register_type: holding
     address: 190
     unit_of_measurement: "W"
@@ -128,7 +131,7 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "Battery Current"
+    name: "${prefix}Battery Current"
     register_type: holding
     address: 191
     unit_of_measurement: "A"
@@ -143,8 +146,8 @@ select:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "Battery Operation Mode"
-    id: battery_operation_mode
+    name: "${prefix}Battery Operation Mode"
+    id: "${prefix}battery_operation_mode"
     address: 213
     value_type: U_WORD
     entity_category: config
@@ -157,7 +160,7 @@ select:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "Battery BMS Type"
+    name: "${prefix}Battery BMS Type"
     address: 325
     value_type: U_WORD
     icon: "mdi:battery-charging-high"
@@ -178,8 +181,8 @@ select:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "Battery Type"
-    id: battery_type
+    name: "${prefix}Battery Type"
+    id: "${prefix}battery_type"
     address: 200
     value_type: U_WORD
     entity_category: config
@@ -192,7 +195,7 @@ switch:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "Battery Wake Up"
+    name: "${prefix}Battery Wake Up"
     register_type: holding
     address: 214
     bitmask: 1 # Bit0: Battery 1 wake up (0=enabled, 1=disabled)
@@ -202,7 +205,7 @@ switch:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "Battery Generator Charging"
+    name: "${prefix}Battery Generator Charging"
     register_type: holding
     address: 231
     bitmask: 1
@@ -212,7 +215,7 @@ switch:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "Battery Grid Charging"
+    name: "${prefix}Battery Grid Charging"
     register_type: holding
     address: 232
     bitmask: 1
@@ -223,7 +226,7 @@ number:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "Battery Generator Charging Start Voltage"
+    name: "${prefix}Battery Generator Charging Start Voltage"
     address: 225
     unit_of_measurement: "V"
     device_class: voltage
@@ -239,7 +242,7 @@ number:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "Battery Generator Charging Start SOC"
+    name: "${prefix}Battery Generator Charging Start SOC"
     address: 226
     unit_of_measurement: "%"
     value_type: U_WORD
@@ -253,7 +256,7 @@ number:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "Battery Generator Charging Current"
+    name: "${prefix}Battery Generator Charging Current"
     address: 227
     unit_of_measurement: "A"
     device_class: current
@@ -268,7 +271,7 @@ number:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "Battery Grid Charging Start Voltage"
+    name: "${prefix}Battery Grid Charging Start Voltage"
     address: 228
     unit_of_measurement: "V"
     device_class: voltage
@@ -284,7 +287,7 @@ number:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "Battery Grid Charging Start SOC"
+    name: "${prefix}Battery Grid Charging Start SOC"
     address: 229
     unit_of_measurement: "%"
     value_type: U_WORD
@@ -298,7 +301,7 @@ number:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "Battery Equalization Cycle"
+    name: "${prefix}Battery Equalization Cycle"
     address: 207
     unit_of_measurement: "d"
     device_class: duration
@@ -313,7 +316,7 @@ number:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "Battery Equalization Time"
+    name: "${prefix}Battery Equalization Time"
     address: 208
     unit_of_measurement: "h"
     device_class: duration
@@ -329,7 +332,7 @@ number:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "Battery Temperature Compensation"
+    name: "${prefix}Battery Temperature Compensation"
     address: 209
     unit_of_measurement: "mV/°C"
     value_type: S_WORD
@@ -343,7 +346,7 @@ number:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "Battery Resistance"
+    name: "${prefix}Battery Resistance"
     address: 215
     unit_of_measurement: "mΩ"
     value_type: U_WORD
@@ -357,7 +360,7 @@ number:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "Battery Charging Efficiency"
+    name: "${prefix}Battery Charging Efficiency"
     address: 216
     unit_of_measurement: "%"
     value_type: U_WORD
@@ -372,7 +375,7 @@ number:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "Battery Shutdown SOC"
+    name: "${prefix}Battery Shutdown SOC"
     address: 217
     unit_of_measurement: "%"
     value_type: U_WORD
@@ -386,7 +389,7 @@ number:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "Battery Restart SOC"
+    name: "${prefix}Battery Restart SOC"
     address: 218
     unit_of_measurement: "%"
     value_type: U_WORD
@@ -400,7 +403,7 @@ number:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "Battery Low SOC"
+    name: "${prefix}Battery Low SOC"
     address: 219
     unit_of_measurement: "%"
     value_type: U_WORD
@@ -414,7 +417,7 @@ number:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "Battery Shutdown Voltage"
+    name: "${prefix}Battery Shutdown Voltage"
     address: 220
     unit_of_measurement: "V"
     device_class: voltage
@@ -430,7 +433,7 @@ number:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "Battery Restart Voltage"
+    name: "${prefix}Battery Restart Voltage"
     address: 221
     unit_of_measurement: "V"
     device_class: voltage
@@ -446,7 +449,7 @@ number:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "Battery Low Voltage"
+    name: "${prefix}Battery Low Voltage"
     address: 222
     unit_of_measurement: "V"
     device_class: voltage
@@ -462,7 +465,7 @@ number:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "Battery Equalization Voltage"
+    name: "${prefix}Battery Equalization Voltage"
     address: 201
     unit_of_measurement: "V"
     device_class: voltage
@@ -478,7 +481,7 @@ number:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "Battery Absorption Voltage"
+    name: "${prefix}Battery Absorption Voltage"
     address: 202
     unit_of_measurement: "V"
     device_class: voltage
@@ -494,7 +497,7 @@ number:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "Battery Float Voltage"
+    name: "${prefix}Battery Float Voltage"
     address: 203
     unit_of_measurement: "V"
     device_class: voltage
@@ -510,7 +513,7 @@ number:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "Battery Capacity"
+    name: "${prefix}Battery Capacity"
     address: 204
     unit_of_measurement: "Ah"
     value_type: U_WORD
@@ -524,7 +527,7 @@ number:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "Battery Empty Voltage"
+    name: "${prefix}Battery Empty Voltage"
     address: 205
     unit_of_measurement: "V"
     device_class: voltage
@@ -540,8 +543,8 @@ number:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    id: maximum_battery_charge_current
-    name: "Maximum Battery Charge Current"
+    id: "${prefix}maximum_battery_charge_current"
+    name: "${prefix}Maximum Battery Charge Current"
     address: 210
     unit_of_measurement: A
     device_class: current
@@ -553,8 +556,8 @@ number:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    id: maximum_battery_discharge_current
-    name: "Maximum Battery Discharge Current"
+    id: "${prefix}maximum_battery_discharge_current"
+    name: "${prefix}Maximum Battery Discharge Current"
     address: 211
     unit_of_measurement: A
     device_class: current
@@ -566,7 +569,7 @@ number:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "Maximum Battery Grid Charge Current"
+    name: "${prefix}Maximum Battery Grid Charge Current"
     address: 230
     unit_of_measurement: A
     entity_category: config

--- a/pv_inverter/packages/deye_hybrid_1p/battery.yaml
+++ b/pv_inverter/packages/deye_hybrid_1p/battery.yaml
@@ -49,7 +49,7 @@ sensor:
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
     name: "${prefix}Total Battery Charge"
-    id: "${prefix}"${prefix}total_battery_charge"
+    id: "${prefix}total_battery_charge"
     register_type: holding
     address: 72
     unit_of_measurement: "kWh"
@@ -64,7 +64,7 @@ sensor:
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
     name: "${prefix}Total Battery Discharge"
-    id: "${prefix}"${prefix}total_battery_discharge"
+    id: "${prefix}total_battery_discharge"
     register_type: holding
     address: 74
     unit_of_measurement: "kWh"

--- a/pv_inverter/packages/deye_hybrid_1p/battery.yaml
+++ b/pv_inverter/packages/deye_hybrid_1p/battery.yaml
@@ -13,12 +13,13 @@
 # limitations under the License.
 
 substitutions:
-  prefix: ""
+  nameprefix: ""   # No Prefix (Single-Inverter)
+  prefix: ""       # No Prefix (Single-Inverter)
 
 sensor:
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}Daily Battery Charge"
+    name: "${nameprefix}Daily Battery Charge"
     id: "${prefix}daily_battery_charge"
     register_type: holding
     address: 70
@@ -33,7 +34,7 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}Daily Battery Discharge"
+    name: "${nameprefix}Daily Battery Discharge"
     id: "${prefix}daily_battery_discharge"
     register_type: holding
     address: 71
@@ -48,7 +49,7 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}Total Battery Charge"
+    name: "${nameprefix}Total Battery Charge"
     id: "${prefix}total_battery_charge"
     register_type: holding
     address: 72
@@ -63,7 +64,7 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}Total Battery Discharge"
+    name: "${nameprefix}Total Battery Discharge"
     id: "${prefix}total_battery_discharge"
     register_type: holding
     address: 74
@@ -78,7 +79,7 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}Battery Temperature"
+    name: "${nameprefix}Battery Temperature"
     register_type: holding
     address: 182
     unit_of_measurement: "°C"
@@ -92,7 +93,7 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}Battery Voltage"
+    name: "${nameprefix}Battery Voltage"
     id: "${prefix}battery_voltage"
     register_type: holding
     address: 183
@@ -106,7 +107,7 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}Battery"
+    name: "${nameprefix}Battery"
     register_type: holding
     address: 184
     unit_of_measurement: "%"
@@ -118,7 +119,7 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}Battery Power"
+    name: "${nameprefix}Battery Power"
     id: "${prefix}battery_power"
     register_type: holding
     address: 190
@@ -131,7 +132,7 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}Battery Current"
+    name: "${nameprefix}Battery Current"
     register_type: holding
     address: 191
     unit_of_measurement: "A"
@@ -146,7 +147,7 @@ select:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}Battery Operation Mode"
+    name: "${nameprefix}Battery Operation Mode"
     id: "${prefix}battery_operation_mode"
     address: 213
     value_type: U_WORD
@@ -160,7 +161,7 @@ select:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}Battery BMS Type"
+    name: "${nameprefix}Battery BMS Type"
     address: 325
     value_type: U_WORD
     icon: "mdi:battery-charging-high"
@@ -181,7 +182,7 @@ select:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}Battery Type"
+    name: "${nameprefix}Battery Type"
     id: "${prefix}battery_type"
     address: 200
     value_type: U_WORD
@@ -195,7 +196,7 @@ switch:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}Battery Wake Up"
+    name: "${nameprefix}Battery Wake Up"
     register_type: holding
     address: 214
     bitmask: 1 # Bit0: Battery 1 wake up (0=enabled, 1=disabled)
@@ -205,7 +206,7 @@ switch:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}Battery Generator Charging"
+    name: "${nameprefix}Battery Generator Charging"
     register_type: holding
     address: 231
     bitmask: 1
@@ -215,7 +216,7 @@ switch:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}Battery Grid Charging"
+    name: "${nameprefix}Battery Grid Charging"
     register_type: holding
     address: 232
     bitmask: 1
@@ -226,7 +227,7 @@ number:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}Battery Generator Charging Start Voltage"
+    name: "${nameprefix}Battery Generator Charging Start Voltage"
     address: 225
     unit_of_measurement: "V"
     device_class: voltage
@@ -242,7 +243,7 @@ number:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}Battery Generator Charging Start SOC"
+    name: "${nameprefix}Battery Generator Charging Start SOC"
     address: 226
     unit_of_measurement: "%"
     value_type: U_WORD
@@ -256,7 +257,7 @@ number:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}Battery Generator Charging Current"
+    name: "${nameprefix}Battery Generator Charging Current"
     address: 227
     unit_of_measurement: "A"
     device_class: current
@@ -271,7 +272,7 @@ number:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}Battery Grid Charging Start Voltage"
+    name: "${nameprefix}Battery Grid Charging Start Voltage"
     address: 228
     unit_of_measurement: "V"
     device_class: voltage
@@ -287,7 +288,7 @@ number:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}Battery Grid Charging Start SOC"
+    name: "${nameprefix}Battery Grid Charging Start SOC"
     address: 229
     unit_of_measurement: "%"
     value_type: U_WORD
@@ -301,7 +302,7 @@ number:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}Battery Equalization Cycle"
+    name: "${nameprefix}Battery Equalization Cycle"
     address: 207
     unit_of_measurement: "d"
     device_class: duration
@@ -316,7 +317,7 @@ number:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}Battery Equalization Time"
+    name: "${nameprefix}Battery Equalization Time"
     address: 208
     unit_of_measurement: "h"
     device_class: duration
@@ -332,7 +333,7 @@ number:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}Battery Temperature Compensation"
+    name: "${nameprefix}Battery Temperature Compensation"
     address: 209
     unit_of_measurement: "mV/°C"
     value_type: S_WORD
@@ -346,7 +347,7 @@ number:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}Battery Resistance"
+    name: "${nameprefix}Battery Resistance"
     address: 215
     unit_of_measurement: "mΩ"
     value_type: U_WORD
@@ -360,7 +361,7 @@ number:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}Battery Charging Efficiency"
+    name: "${nameprefix}Battery Charging Efficiency"
     address: 216
     unit_of_measurement: "%"
     value_type: U_WORD
@@ -375,7 +376,7 @@ number:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}Battery Shutdown SOC"
+    name: "${nameprefix}Battery Shutdown SOC"
     address: 217
     unit_of_measurement: "%"
     value_type: U_WORD
@@ -389,7 +390,7 @@ number:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}Battery Restart SOC"
+    name: "${nameprefix}Battery Restart SOC"
     address: 218
     unit_of_measurement: "%"
     value_type: U_WORD
@@ -403,7 +404,7 @@ number:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}Battery Low SOC"
+    name: "${nameprefix}Battery Low SOC"
     address: 219
     unit_of_measurement: "%"
     value_type: U_WORD
@@ -417,7 +418,7 @@ number:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}Battery Shutdown Voltage"
+    name: "${nameprefix}Battery Shutdown Voltage"
     address: 220
     unit_of_measurement: "V"
     device_class: voltage
@@ -433,7 +434,7 @@ number:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}Battery Restart Voltage"
+    name: "${nameprefix}Battery Restart Voltage"
     address: 221
     unit_of_measurement: "V"
     device_class: voltage
@@ -449,7 +450,7 @@ number:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}Battery Low Voltage"
+    name: "${nameprefix}Battery Low Voltage"
     address: 222
     unit_of_measurement: "V"
     device_class: voltage
@@ -465,7 +466,7 @@ number:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}Battery Equalization Voltage"
+    name: "${nameprefix}Battery Equalization Voltage"
     address: 201
     unit_of_measurement: "V"
     device_class: voltage
@@ -481,7 +482,7 @@ number:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}Battery Absorption Voltage"
+    name: "${nameprefix}Battery Absorption Voltage"
     address: 202
     unit_of_measurement: "V"
     device_class: voltage
@@ -497,7 +498,7 @@ number:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}Battery Float Voltage"
+    name: "${nameprefix}Battery Float Voltage"
     address: 203
     unit_of_measurement: "V"
     device_class: voltage
@@ -513,7 +514,7 @@ number:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}Battery Capacity"
+    name: "${nameprefix}Battery Capacity"
     address: 204
     unit_of_measurement: "Ah"
     value_type: U_WORD
@@ -527,7 +528,7 @@ number:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}Battery Empty Voltage"
+    name: "${nameprefix}Battery Empty Voltage"
     address: 205
     unit_of_measurement: "V"
     device_class: voltage
@@ -544,7 +545,7 @@ number:
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
     id: "${prefix}maximum_battery_charge_current"
-    name: "${prefix}Maximum Battery Charge Current"
+    name: "${nameprefix}Maximum Battery Charge Current"
     address: 210
     unit_of_measurement: A
     device_class: current
@@ -557,7 +558,7 @@ number:
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
     id: "${prefix}maximum_battery_discharge_current"
-    name: "${prefix}Maximum Battery Discharge Current"
+    name: "${nameprefix}Maximum Battery Discharge Current"
     address: 211
     unit_of_measurement: A
     device_class: current
@@ -569,7 +570,7 @@ number:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}Maximum Battery Grid Charge Current"
+    name: "${nameprefix}Maximum Battery Grid Charge Current"
     address: 230
     unit_of_measurement: A
     entity_category: config

--- a/pv_inverter/packages/deye_hybrid_1p/device.yaml
+++ b/pv_inverter/packages/deye_hybrid_1p/device.yaml
@@ -14,7 +14,7 @@
 sensor:
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "Device Modbus Address"
+    name: "${prefix}Device Modbus Address"
     register_type: holding
     address: 1
     unit_of_measurement: ""
@@ -25,8 +25,8 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: Device Rated Power
-    id: device_rated_power_raw
+    name: "${prefix}Device Rated Power
+    id: "${prefix}device_rated_power_raw"
     register_type: holding
     address: 16
     unit_of_measurement: W
@@ -40,7 +40,7 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: Device MPPTs
+    name: "${prefix}Device MPPTs"
     register_type: holding
     address: 18
     unit_of_measurement: ""
@@ -61,7 +61,7 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: Device Phases
+    name: "${prefix}Device Phases"
     register_type: holding
     address: 18
     unit_of_measurement: ""
@@ -83,8 +83,8 @@ sensor:
 binary_sensor:
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "Grid Connected Status"
-    id: grid_connected_status
+    name: "${prefix}Grid Connected Status"
+    id: "${prefix}grid_connected_status"
     register_type: holding
     address: 194
     device_class: running
@@ -94,8 +94,8 @@ switch:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: Power Switch
-    id: switch_power
+    name: "${prefix}Power Switch"
+    id: "${prefix}switch_power"
     register_type: holding
     address: 43
     bitmask: 1
@@ -109,7 +109,7 @@ text_sensor:
     register_type: holding
     address: 59
     raw_encode: HEXBYTES
-    name: Running Status
+    name: "${prefix}Running Status"
     icon: mdi:play-circle
     lambda: |-
       uint16_t value = modbus_controller::word_from_hex_str(x, 0);
@@ -125,7 +125,7 @@ text_sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: Device Type
+    name: "${prefix}Device Type"
     register_type: holding
     address: 0
     bitmask: 0
@@ -154,7 +154,7 @@ text_sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: Device Serial Number
+    name: "${prefix}Device Serial Number"
     register_type: holding
     address: 3
     response_size: 10
@@ -176,7 +176,7 @@ text_sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "Device Protocol Version"
+    name: "${prefix}Device Protocol Version"
     register_type: holding
     address: 2
     bitmask: 0
@@ -192,7 +192,7 @@ text_sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "Device Chip Type"
+    name: "${prefix}Device Chip Type"
     register_type: holding
     address: 9
     bitmask: 0
@@ -216,7 +216,7 @@ text_sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "Device Comm Board Firmware Field 2"
+    name: "${prefix}Device Comm Board Firmware Field 2"
     register_type: holding
     address: 10
     bitmask: 0
@@ -232,7 +232,7 @@ text_sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "Device Control Board Aux Version"
+    name: "${prefix}Device Control Board Aux Version"
     register_type: holding
     address: 11
     bitmask: 0
@@ -248,7 +248,7 @@ text_sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "Device Control Board Firmware Field 2"
+    name: "${prefix}Device Control Board Firmware Field 2"
     register_type: holding
     address: 12
     bitmask: 0
@@ -264,7 +264,7 @@ text_sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "Device Control Board Firmware Version"
+    name: "${prefix}Device Control Board Firmware Version"
     register_type: holding
     address: 13
     bitmask: 0
@@ -280,7 +280,7 @@ text_sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "Device Comm Board Firmware Version"
+    name: "${prefix}Device Comm Board Firmware Version"
     register_type: holding
     address: 14
     bitmask: 0
@@ -296,7 +296,7 @@ text_sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "Device Alarm"
+    name: "${prefix}Device Alarm"
     register_type: holding
     entity_category: diagnostic
     address: 101
@@ -323,7 +323,7 @@ text_sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "Device Fault"
+    name: "${prefix}Device Fault"
     register_type: holding
     address: 103
     response_size: 8
@@ -359,8 +359,8 @@ number:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "Self Check Time"
-    id: self_check_time
+    name: "${prefix}Self Check Time"
+    id: "${prefix}self_check_time
     register_type: holding
     address: 61
     unit_of_measurement: "s"
@@ -375,7 +375,7 @@ select:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "Meter"
+    name: "${prefix}Meter"
     address: 326
     value_type: U_WORD
     entity_category: config

--- a/pv_inverter/packages/deye_hybrid_1p/device.yaml
+++ b/pv_inverter/packages/deye_hybrid_1p/device.yaml
@@ -11,10 +11,15 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+substitutions:
+  nameprefix: ""   # No Prefix (Single-Inverter)
+  prefix: ""       # No Prefix (Single-Inverter)
+  
 sensor:
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}Device Modbus Address"
+    name: "${nameprefix}Device Modbus Address"
     register_type: holding
     address: 1
     unit_of_measurement: ""
@@ -25,7 +30,7 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}Device Rated Power"
+    name: "${nameprefix}Device Rated Power"
     id: "${prefix}device_rated_power_raw"
     register_type: holding
     address: 16
@@ -40,7 +45,7 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}Device MPPTs"
+    name: "${nameprefix}Device MPPTs"
     register_type: holding
     address: 18
     unit_of_measurement: ""
@@ -61,7 +66,7 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}Device Phases"
+    name: "${nameprefix}Device Phases"
     register_type: holding
     address: 18
     unit_of_measurement: ""
@@ -83,7 +88,7 @@ sensor:
 binary_sensor:
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}Grid Connected Status"
+    name: "${nameprefix}Grid Connected Status"
     id: "${prefix}grid_connected_status"
     register_type: holding
     address: 194
@@ -94,7 +99,7 @@ switch:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}Power Switch"
+    name: "${nameprefix}Power Switch"
     id: "${prefix}switch_power"
     register_type: holding
     address: 43
@@ -109,7 +114,7 @@ text_sensor:
     register_type: holding
     address: 59
     raw_encode: HEXBYTES
-    name: "${prefix}Running Status"
+    name: "${nameprefix}Running Status"
     icon: mdi:play-circle
     lambda: |-
       uint16_t value = modbus_controller::word_from_hex_str(x, 0);
@@ -125,7 +130,7 @@ text_sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}Device Type"
+    name: "${nameprefix}Device Type"
     register_type: holding
     address: 0
     bitmask: 0
@@ -154,7 +159,7 @@ text_sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}Device Serial Number"
+    name: "${nameprefix}Device Serial Number"
     register_type: holding
     address: 3
     response_size: 10
@@ -176,7 +181,7 @@ text_sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}Device Protocol Version"
+    name: "${nameprefix}Device Protocol Version"
     register_type: holding
     address: 2
     bitmask: 0
@@ -192,7 +197,7 @@ text_sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}Device Chip Type"
+    name: "${nameprefix}Device Chip Type"
     register_type: holding
     address: 9
     bitmask: 0
@@ -216,7 +221,7 @@ text_sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}Device Comm Board Firmware Field 2"
+    name: "${nameprefix}Device Comm Board Firmware Field 2"
     register_type: holding
     address: 10
     bitmask: 0
@@ -232,7 +237,7 @@ text_sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}Device Control Board Aux Version"
+    name: "${nameprefix}Device Control Board Aux Version"
     register_type: holding
     address: 11
     bitmask: 0
@@ -248,7 +253,7 @@ text_sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}Device Control Board Firmware Field 2"
+    name: "${nameprefix}Device Control Board Firmware Field 2"
     register_type: holding
     address: 12
     bitmask: 0
@@ -264,7 +269,7 @@ text_sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}Device Control Board Firmware Version"
+    name: "${nameprefix}Device Control Board Firmware Version"
     register_type: holding
     address: 13
     bitmask: 0
@@ -280,7 +285,7 @@ text_sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}Device Comm Board Firmware Version"
+    name: "${nameprefix}Device Comm Board Firmware Version"
     register_type: holding
     address: 14
     bitmask: 0
@@ -296,7 +301,7 @@ text_sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}Device Alarm"
+    name: "${nameprefix}Device Alarm"
     register_type: holding
     entity_category: diagnostic
     address: 101
@@ -323,7 +328,7 @@ text_sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}Device Fault"
+    name: "${nameprefix}Device Fault"
     register_type: holding
     address: 103
     response_size: 8
@@ -359,7 +364,7 @@ number:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}Self Check Time"
+    name: "${nameprefix}Self Check Time"
     id: "${prefix}self_check_time"
     register_type: holding
     address: 61
@@ -375,7 +380,7 @@ select:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}Meter"
+    name: "${nameprefix}Meter"
     address: 326
     value_type: U_WORD
     entity_category: config

--- a/pv_inverter/packages/deye_hybrid_1p/device.yaml
+++ b/pv_inverter/packages/deye_hybrid_1p/device.yaml
@@ -360,7 +360,7 @@ number:
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
     name: "${prefix}Self Check Time"
-    id: "${prefix}self_check_time
+    id: "${prefix}self_check_time"
     register_type: holding
     address: 61
     unit_of_measurement: "s"

--- a/pv_inverter/packages/deye_hybrid_1p/device.yaml
+++ b/pv_inverter/packages/deye_hybrid_1p/device.yaml
@@ -25,7 +25,7 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}Device Rated Power
+    name: "${prefix}Device Rated Power"
     id: "${prefix}device_rated_power_raw"
     register_type: holding
     address: 16

--- a/pv_inverter/packages/deye_hybrid_1p/gen.yaml
+++ b/pv_inverter/packages/deye_hybrid_1p/gen.yaml
@@ -114,7 +114,7 @@ switch:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}Generator
+    name: "${prefix}Generator"
     id: "${prefix}switch_generator"
     register_type: holding
     address: 234

--- a/pv_inverter/packages/deye_hybrid_1p/gen.yaml
+++ b/pv_inverter/packages/deye_hybrid_1p/gen.yaml
@@ -11,11 +11,15 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+substitutions:
+  prefix: ""
+
 sensor:
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "Daily Generator Production"
-    id: daily_generator_production
+    name: "${prefix}Daily Generator Production"
+    id: "${prefix}daily_generator_production"
     register_type: holding
     address: 62
     unit_of_measurement: "kWh"
@@ -29,8 +33,8 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "Total Generator Production"
-    id: total_generator_production
+    name: "${prefix}Total Generator Production"
+    id: "${prefix}total_generator_production"
     register_type: holding
     address: 92
     unit_of_measurement: "kWh"
@@ -44,8 +48,8 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "Generator L1 Voltage"
-    id: generator_l1_voltage
+    name: "${prefix}Generator L1 Voltage"
+    id: "${prefix}generator_l1_voltage"
     register_type: holding
     address: 181
     unit_of_measurement: "V"
@@ -58,7 +62,7 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "Generator Frequency"
+    name: "${prefix}Generator Frequency"
     register_type: holding
     address: 196
     unit_of_measurement: "Hz"
@@ -71,8 +75,8 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "Generator Power Total"
-    id: generator_power_total
+    name: "${prefix}Generator Power Total"
+    id: "${prefix}generator_power_total"
     register_type: holding
     address: 166
     unit_of_measurement: "W"
@@ -85,8 +89,8 @@ sensor:
 binary_sensor:
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "Generator Connected Status"
-    id: generator_connected_status
+    name: "${prefix}Generator Connected Status"
+    id: "${prefix}generator_connected_status"
     register_type: holding
     address: 195
     device_class: running
@@ -96,7 +100,7 @@ select:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "Generator Port Use"
+    name: "${prefix}Generator Port Use"
     address: 235
     value_type: U_WORD
     entity_category: config
@@ -110,8 +114,8 @@ switch:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: Generator
-    id: switch_generator
+    name: "${prefix}Generator
+    id: "${prefix}switch_generator"
     register_type: holding
     address: 234
     bitmask: 1
@@ -122,7 +126,7 @@ number:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "SmartLoad Off Voltage"
+    name: "${prefix}SmartLoad Off Voltage"
     address: 236
     unit_of_measurement: "V"
     device_class: voltage
@@ -138,7 +142,7 @@ number:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "SmartLoad Off SOC"
+    name: "${prefix}SmartLoad Off SOC"
     address: 237
     unit_of_measurement: "%"
     value_type: U_WORD
@@ -152,7 +156,7 @@ number:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "SmartLoad On Voltage"
+    name: "${prefix}SmartLoad On Voltage"
     address: 238
     unit_of_measurement: "V"
     device_class: voltage
@@ -168,7 +172,7 @@ number:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "SmartLoad On SOC"
+    name: "${prefix}SmartLoad On SOC"
     address: 239
     unit_of_measurement: "%"
     value_type: U_WORD
@@ -182,8 +186,8 @@ number:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "Generator Operating Time"
-    id: generator_operating_time
+    name: "${prefix}Generator Operating Time"
+    id: "${prefix}generator_operating_time"
     unit_of_measurement: "h"
     device_class: duration
     entity_category: config
@@ -199,8 +203,8 @@ number:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "Generator Cooling Time"
-    id: generator_cooling_time
+    name: "${prefix}Generator Cooling Time"
+    id: "${prefix}generator_cooling_time"
     unit_of_measurement: "h"
     device_class: duration
     entity_category: config
@@ -216,8 +220,8 @@ number:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "Generator Min PV Power"
-    id: generator_min_pv_power
+    name: "${prefix}Generator Min PV Power"
+    id: "${prefix}generator_min_pv_power"
     unit_of_measurement: "W"
     device_class: power
     entity_category: config

--- a/pv_inverter/packages/deye_hybrid_1p/gen.yaml
+++ b/pv_inverter/packages/deye_hybrid_1p/gen.yaml
@@ -13,12 +13,13 @@
 # limitations under the License.
 
 substitutions:
-  prefix: ""
+  nameprefix: ""   # No Prefix (Single-Inverter)
+  prefix: ""       # No Prefix (Single-Inverter)
 
 sensor:
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}Daily Generator Production"
+    name: "${nameprefix}Daily Generator Production"
     id: "${prefix}daily_generator_production"
     register_type: holding
     address: 62
@@ -33,7 +34,7 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}Total Generator Production"
+    name: "${nameprefix}Total Generator Production"
     id: "${prefix}total_generator_production"
     register_type: holding
     address: 92
@@ -48,7 +49,7 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}Generator L1 Voltage"
+    name: "${nameprefix}Generator L1 Voltage"
     id: "${prefix}generator_l1_voltage"
     register_type: holding
     address: 181
@@ -62,7 +63,7 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}Generator Frequency"
+    name: "${nameprefix}Generator Frequency"
     register_type: holding
     address: 196
     unit_of_measurement: "Hz"
@@ -75,7 +76,7 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}Generator Power Total"
+    name: "${nameprefix}Generator Power Total"
     id: "${prefix}generator_power_total"
     register_type: holding
     address: 166
@@ -89,7 +90,7 @@ sensor:
 binary_sensor:
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}Generator Connected Status"
+    name: "${nameprefix}Generator Connected Status"
     id: "${prefix}generator_connected_status"
     register_type: holding
     address: 195
@@ -100,7 +101,7 @@ select:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}Generator Port Use"
+    name: "${nameprefix}Generator Port Use"
     address: 235
     value_type: U_WORD
     entity_category: config
@@ -114,7 +115,7 @@ switch:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}Generator"
+    name: "${nameprefix}Generator"
     id: "${prefix}switch_generator"
     register_type: holding
     address: 234
@@ -126,7 +127,7 @@ number:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}SmartLoad Off Voltage"
+    name: "${nameprefix}SmartLoad Off Voltage"
     address: 236
     unit_of_measurement: "V"
     device_class: voltage
@@ -142,7 +143,7 @@ number:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}SmartLoad Off SOC"
+    name: "${nameprefix}SmartLoad Off SOC"
     address: 237
     unit_of_measurement: "%"
     value_type: U_WORD
@@ -156,7 +157,7 @@ number:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}SmartLoad On Voltage"
+    name: "${nameprefix}SmartLoad On Voltage"
     address: 238
     unit_of_measurement: "V"
     device_class: voltage
@@ -172,7 +173,7 @@ number:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}SmartLoad On SOC"
+    name: "${nameprefix}SmartLoad On SOC"
     address: 239
     unit_of_measurement: "%"
     value_type: U_WORD
@@ -186,7 +187,7 @@ number:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}Generator Operating Time"
+    name: "${nameprefix}Generator Operating Time"
     id: "${prefix}generator_operating_time"
     unit_of_measurement: "h"
     device_class: duration
@@ -203,7 +204,7 @@ number:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}Generator Cooling Time"
+    name: "${nameprefix}Generator Cooling Time"
     id: "${prefix}generator_cooling_time"
     unit_of_measurement: "h"
     device_class: duration
@@ -220,7 +221,7 @@ number:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}Generator Min PV Power"
+    name: "${nameprefix}Generator Min PV Power"
     id: "${prefix}generator_min_pv_power"
     unit_of_measurement: "W"
     device_class: power

--- a/pv_inverter/packages/deye_hybrid_1p/grid.yaml
+++ b/pv_inverter/packages/deye_hybrid_1p/grid.yaml
@@ -12,6 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+substitutions:
+  nameprefix: ""   # No Prefix (Single-Inverter)
+  prefix: ""       # No Prefix (Single-Inverter)
+  
 globals:
   - id: "${prefix}last_total_energy_bought"
     type: float
@@ -23,7 +27,7 @@ globals:
 sensor:
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}Grid L1 Power"
+    name: "${nameprefix}Grid L1 Power"
     register_type: holding
     address: 167
     unit_of_measurement: "W"
@@ -35,7 +39,7 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}Grid L2 Power"
+    name: "${nameprefix}Grid L2 Power"
     register_type: holding
     address: 168
     unit_of_measurement: "W"
@@ -47,7 +51,7 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}Grid Power"
+    name: "${nameprefix}Grid Power"
     register_type: holding
     address: 169
     unit_of_measurement: "W"
@@ -59,7 +63,7 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}Grid Frequency"
+    name: "${nameprefix}Grid Frequency"
     register_type: holding
     address: 79
     unit_of_measurement: "Hz"
@@ -72,7 +76,7 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}Grid L1 Voltage"
+    name: "${nameprefix}Grid L1 Voltage"
     id: "${prefix}grid_voltage_l1"
     register_type: holding
     address: 150
@@ -86,7 +90,7 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}Grid L2 Voltage"
+    name: "${nameprefix}Grid L2 Voltage"
     id: "${prefix}grid_voltage_l2"
     register_type: holding
     address: 151
@@ -100,7 +104,7 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}Grid Voltage"
+    name: "${nameprefix}Grid Voltage"
     id: "${prefix}grid_voltage"
     register_type: holding
     address: 152
@@ -114,7 +118,7 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}Daily Energy Bought"
+    name: "${nameprefix}Daily Energy Bought"
     id: "${prefix}daily_energy_bought"
     register_type: holding
     address: 76
@@ -129,7 +133,7 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}Daily Energy Sold"
+    name: "${nameprefix}Daily Energy Sold"
     id: "${prefix}daily_energy_sold"
     register_type: holding
     address: 77
@@ -161,7 +165,7 @@ sensor:
 
   # Main sensor + fix
   - platform: template
-    name: "${prefix}Total Energy Bought"
+    name: "${nameprefix}Total Energy Bought"
     id: "${prefix}total_energy_bought"
     unit_of_measurement: "kWh"
     device_class: energy
@@ -190,7 +194,7 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}Total Energy Sold"
+    name: "${nameprefix}Total Energy Sold"
     id: "${prefix}total_energy_sold"
     register_type: holding
     address: 81
@@ -205,7 +209,7 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}External CT L1 Power"
+    name: "${nameprefix}External CT L1 Power"
     register_type: holding
     address: 170
     unit_of_measurement: "W"
@@ -216,7 +220,7 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}External CT L2 Power"
+    name: "${nameprefix}External CT L2 Power"
     register_type: holding
     address: 171
     unit_of_measurement: "W"
@@ -227,7 +231,7 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}External CT Power"
+    name: "${nameprefix}External CT Power"
     register_type: holding
     address: 172
     unit_of_measurement: "W"
@@ -238,7 +242,7 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}External CT L1 Current"
+    name: "${nameprefix}External CT L1 Current"
     id: "${prefix}external_ct_l1_current"
     register_type: holding
     address: 162
@@ -252,7 +256,7 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}External CT L2 Current"
+    name: "${nameprefix}External CT L2 Current"
     id: "${prefix}external_ct_l2_current"
     register_type: holding
     address: 163
@@ -268,7 +272,7 @@ select:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}Grid Frequency"
+    name: "${nameprefix}Grid Frequency"
     address: 285
     value_type: U_WORD
     entity_category: config
@@ -280,7 +284,7 @@ select:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}Charging Signal"
+    name: "${nameprefix}Charging Signal"
     address: 242
     value_type: U_WORD
     entity_category: config
@@ -295,7 +299,7 @@ switch:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}Force Off Grid"
+    name: "${nameprefix}Force Off Grid"
     id: "${prefix}switch_off_grid"
     register_type: holding
     address: 281
@@ -306,7 +310,7 @@ switch:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}Generator Grid Side"
+    name: "${nameprefix}Generator Grid Side"
     register_type: holding
     address: 280
     bitmask: 12
@@ -318,7 +322,7 @@ number:
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
     id: "${prefix}grid_voltage_protection_high"
-    name: "${prefix}Grid voltage protection - high"
+    name: "${nameprefix}Grid voltage protection - high"
     unit_of_measurement: "V"
     device_class: voltage
     entity_category: config
@@ -336,7 +340,7 @@ number:
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
     id: "${prefix}grid_voltage_protection_low"
-    name: "${prefix}Grid voltage protection - low"
+    name: "${nameprefix}Grid voltage protection - low"
     unit_of_measurement: "V"
     device_class: voltage
     entity_category: config
@@ -354,7 +358,7 @@ number:
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
     id: "${prefix}grid_requency_protection_high"
-    name: "${prefix}Grid Frequency Protection - high"
+    name: "${nameprefix}Grid Frequency Protection - high"
     unit_of_measurement: "Hz"
     device_class: frequency
     entity_category: config
@@ -372,7 +376,7 @@ number:
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
     id: "${prefix}grid_requency_protection_low"
-    name: "${prefix}Grid Frequency Protection - low"
+    name: "${nameprefix}Grid Frequency Protection - low"
     unit_of_measurement: "Hz"
     device_class: frequency
     entity_category: config

--- a/pv_inverter/packages/deye_hybrid_1p/grid.yaml
+++ b/pv_inverter/packages/deye_hybrid_1p/grid.yaml
@@ -169,7 +169,7 @@ sensor:
     accuracy_decimals: 1
     icon: "mdi:transmission-tower-import"
     lambda: |-
-      auto high = id(total_energy_bought_high_bytes).state;
+      auto high = id(${prefix}total_energy_bought_high_bytes).state;
       auto low = id(${prefix}total_energy_bought_low_bytes).state;
       if (isnan(high) || isnan(low)) {
         return {}; 

--- a/pv_inverter/packages/deye_hybrid_1p/grid.yaml
+++ b/pv_inverter/packages/deye_hybrid_1p/grid.yaml
@@ -170,7 +170,7 @@ sensor:
     icon: "mdi:transmission-tower-import"
     lambda: |-
       auto high = id(total_energy_bought_high_bytes).state;
-      auto low = id(total_energy_bought_low_bytes).state;
+      auto low = id(${prefix}total_energy_bought_low_bytes).state;
       if (isnan(high) || isnan(low)) {
         return {}; 
       }

--- a/pv_inverter/packages/deye_hybrid_1p/grid.yaml
+++ b/pv_inverter/packages/deye_hybrid_1p/grid.yaml
@@ -13,17 +13,17 @@
 # limitations under the License.
 
 globals:
-  - id: last_total_energy_bought
+  - id: "${prefix}last_total_energy_bought
     type: float
     restore_value: yes
-  - id: last_update_time
+  - id: "${prefix}last_update_time"
     type: unsigned long
     restore_value: yes
 
 sensor:
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "Grid L1 Power"
+    name: "${prefix}Grid L1 Power"
     register_type: holding
     address: 167
     unit_of_measurement: "W"
@@ -35,7 +35,7 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "Grid L2 Power"
+    name: "${prefix}Grid L2 Power"
     register_type: holding
     address: 168
     unit_of_measurement: "W"
@@ -47,7 +47,7 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "Grid Power"
+    name: "${prefix}Grid Power"
     register_type: holding
     address: 169
     unit_of_measurement: "W"
@@ -59,7 +59,7 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "Grid Frequency"
+    name: "${prefix}Grid Frequency"
     register_type: holding
     address: 79
     unit_of_measurement: "Hz"
@@ -72,8 +72,8 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "Grid L1 Voltage"
-    id: grid_voltage_l1
+    name: "${prefix}Grid L1 Voltage"
+    id: "${prefix}grid_voltage_l1"
     register_type: holding
     address: 150
     unit_of_measurement: "V"
@@ -86,8 +86,8 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "Grid L2 Voltage"
-    id: grid_voltage_l2
+    name: "${prefix}Grid L2 Voltage"
+    id: "${prefix}grid_voltage_l2"
     register_type: holding
     address: 151
     unit_of_measurement: "V"
@@ -100,8 +100,8 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "Grid Voltage"
-    id: grid_voltage
+    name: "${prefix}Grid Voltage"
+    id: "${prefix}grid_voltage"
     register_type: holding
     address: 152
     unit_of_measurement: "V"
@@ -114,8 +114,8 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "Daily Energy Bought"
-    id: daily_energy_bought
+    name: "${prefix}Daily Energy Bought"
+    id: "${prefix}daily_energy_bought"
     register_type: holding
     address: 76
     unit_of_measurement: "kWh"
@@ -129,8 +129,8 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "Daily Energy Sold"
-    id: daily_energy_sold
+    name: "${prefix}Daily Energy Sold"
+    id: "${prefix}daily_energy_sold"
     register_type: holding
     address: 77
     unit_of_measurement: "kWh"
@@ -145,7 +145,7 @@ sensor:
   # Axiliary sensor
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    id: total_energy_bought_low_bytes
+    id: "${prefix}total_energy_bought_low_bytes"
     address: 78
     register_type: holding
     value_type: U_WORD
@@ -153,7 +153,7 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    id: total_energy_bought_high_bytes
+    id: "${prefix}total_energy_bought_high_bytes"
     address: 80
     register_type: holding
     value_type: U_WORD
@@ -161,8 +161,8 @@ sensor:
 
   # Main sensor + fix
   - platform: template
-    name: "Total Energy Bought"
-    id: total_energy_bought
+    name: "${prefix}Total Energy Bought"
+    id: "${prefix}total_energy_bought"
     unit_of_measurement: "kWh"
     device_class: energy
     state_class: "total_increasing"
@@ -176,22 +176,22 @@ sensor:
       }
       float calculated_value = (((uint32_t)high << 16) | (uint32_t)low) * 0.1;
       unsigned long now = millis();
-      if (id(last_update_time) > 0 && (now - id(last_update_time) > 3600000)) {
-        id(last_total_energy_bought) = calculated_value;
-        id(last_update_time) = now;
+      if (id(${prefix}last_update_time) > 0 && (now - id(${prefix}last_update_time) > 3600000)) {
+        id(${prefix}last_total_energy_bought) = calculated_value;
+        id(${prefix}last_update_time) = now;
         return calculated_value;
       }
-      if (isnan(id(last_total_energy_bought)) || (calculated_value >= id(last_total_energy_bought) && calculated_value < id(last_total_energy_bought) + 1000.0)) {
-        id(last_total_energy_bought) = calculated_value;
-        id(last_update_time) = now;
+      if (isnan(id(${prefix}last_total_energy_bought)) || (calculated_value >= id(${prefix}last_total_energy_bought) && calculated_value < id(${prefix}last_total_energy_bought) + 1000.0)) {
+        id(${prefix}last_total_energy_bought) = calculated_value;
+        id(${prefix}last_update_time) = now;
         return calculated_value;
       }
       return {};
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "Total Energy Sold"
-    id: total_energy_sold
+    name: "${prefix}Total Energy Sold"
+    id: "${prefix}total_energy_sold"
     register_type: holding
     address: 81
     unit_of_measurement: "kWh"
@@ -205,7 +205,7 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "External CT L1 Power"
+    name: "${prefix}External CT L1 Power"
     register_type: holding
     address: 170
     unit_of_measurement: "W"
@@ -216,7 +216,7 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "External CT L2 Power"
+    name: "${prefix}External CT L2 Power"
     register_type: holding
     address: 171
     unit_of_measurement: "W"
@@ -227,7 +227,7 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "External CT Power"
+    name: "${prefix}External CT Power"
     register_type: holding
     address: 172
     unit_of_measurement: "W"
@@ -238,8 +238,8 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "External CT L1 Current"
-    id: external_ct_l1_current
+    name: "${prefix}External CT L1 Current"
+    id: "${prefix}external_ct_l1_current"
     register_type: holding
     address: 162
     unit_of_measurement: "A"
@@ -252,8 +252,8 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "External CT L2 Current"
-    id: external_ct_l2_current
+    name: "${prefix}External CT L2 Current"
+    id: "${prefix}external_ct_l2_current"
     register_type: holding
     address: 163
     unit_of_measurement: "A"
@@ -268,7 +268,7 @@ select:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "Grid Frequency"
+    name: "${prefix}Grid Frequency"
     address: 285
     value_type: U_WORD
     entity_category: config
@@ -280,7 +280,7 @@ select:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "Charging Signal"
+    name: "${prefix}Charging Signal"
     address: 242
     value_type: U_WORD
     entity_category: config
@@ -295,8 +295,8 @@ switch:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "Force Off Grid"
-    id: switch_off_grid
+    name: "${prefix}Force Off Grid"
+    id: "${prefix}switch_off_grid"
     register_type: holding
     address: 281
     bitmask: 1
@@ -306,7 +306,7 @@ switch:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "Generator Grid Side"
+    name: "${prefix}Generator Grid Side"
     register_type: holding
     address: 280
     bitmask: 12
@@ -317,8 +317,8 @@ number:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    id: grid_voltage_protection_high
-    name: "Grid voltage protection - high"
+    id: "${prefix}grid_voltage_protection_high"
+    name: "${prefix}Grid voltage protection - high"
     unit_of_measurement: "V"
     device_class: voltage
     entity_category: config
@@ -335,8 +335,8 @@ number:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    id: grid_voltage_protection_low
-    name: "Grid voltage protection - low"
+    id: "${prefix}grid_voltage_protection_low"
+    name: "${prefix}Grid voltage protection - low"
     unit_of_measurement: "V"
     device_class: voltage
     entity_category: config
@@ -353,8 +353,8 @@ number:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    id: grid_requency_protection_high
-    name: "Grid Frequency Protection - high"
+    id: "${prefix}grid_requency_protection_high"
+    name: "${prefix}Grid Frequency Protection - high"
     unit_of_measurement: "Hz"
     device_class: frequency
     entity_category: config
@@ -371,8 +371,8 @@ number:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    id: grid_requency_protection_low
-    name: "Grid Frequency Protection - low"
+    id: "${prefix}grid_requency_protection_low"
+    name: "${prefix}Grid Frequency Protection - low"
     unit_of_measurement: "Hz"
     device_class: frequency
     entity_category: config

--- a/pv_inverter/packages/deye_hybrid_1p/grid.yaml
+++ b/pv_inverter/packages/deye_hybrid_1p/grid.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 globals:
-  - id: "${prefix}last_total_energy_bought
+  - id: "${prefix}last_total_energy_bought"
     type: float
     restore_value: yes
   - id: "${prefix}last_update_time"

--- a/pv_inverter/packages/deye_hybrid_1p/inverter.yaml
+++ b/pv_inverter/packages/deye_hybrid_1p/inverter.yaml
@@ -14,7 +14,7 @@
 sensor:
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "DC Temperature"
+    name: "${prefix}DC Temperature"
     register_type: holding
     address: 90
     unit_of_measurement: "°C"
@@ -29,7 +29,7 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "AC Temperature"
+    name: "${prefix}AC Temperature"
     register_type: holding
     address: 91
     unit_of_measurement: "°C"
@@ -43,7 +43,7 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "Output Frequency"
+    name: "${prefix}Output Frequency"
     register_type: holding
     address: 193
     unit_of_measurement: "Hz"
@@ -56,7 +56,7 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "Output L1 Current"
+    name: "${prefix}Output L1 Current"
     register_type: holding
     address: 164
     unit_of_measurement: "A"
@@ -69,7 +69,7 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "Output L2 Current"
+    name: "${prefix}Output L2 Current"
     register_type: holding
     address: 165
     unit_of_measurement: "A"
@@ -82,7 +82,7 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "Output L1 Power"
+    name: "${prefix}Output L1 Power"
     register_type: holding
     address: 173
     unit_of_measurement: "W"
@@ -94,7 +94,7 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "Output L2 Power"
+    name: "${prefix}Output L2 Power"
     register_type: holding
     address: 174
     unit_of_measurement: "W"
@@ -106,8 +106,8 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "Output Power"
-    id: output_power
+    name: "${prefix}Output Power"
+    id: "${prefix}output_power"
     register_type: holding
     address: 175
     unit_of_measurement: "W"
@@ -119,7 +119,7 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "Output L1 Voltage"
+    name: "${prefix}Output L1 Voltage"
     register_type: holding
     address: 154
     unit_of_measurement: "V"
@@ -132,7 +132,7 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "Output L2 Voltage"
+    name: "${prefix}Output L2 Voltage"
     register_type: holding
     address: 155
     unit_of_measurement: "V"

--- a/pv_inverter/packages/deye_hybrid_1p/inverter.yaml
+++ b/pv_inverter/packages/deye_hybrid_1p/inverter.yaml
@@ -11,10 +11,15 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+substitutions:
+  nameprefix: ""   # No Prefix (Single-Inverter)
+  prefix: ""       # No Prefix (Single-Inverter)
+  
 sensor:
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}DC Temperature"
+    name: "${nameprefix}DC Temperature"
     register_type: holding
     address: 90
     unit_of_measurement: "°C"
@@ -29,7 +34,7 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}AC Temperature"
+    name: "${nameprefix}AC Temperature"
     register_type: holding
     address: 91
     unit_of_measurement: "°C"
@@ -43,7 +48,7 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}Output Frequency"
+    name: "${nameprefix}Output Frequency"
     register_type: holding
     address: 193
     unit_of_measurement: "Hz"
@@ -56,7 +61,7 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}Output L1 Current"
+    name: "${nameprefix}Output L1 Current"
     register_type: holding
     address: 164
     unit_of_measurement: "A"
@@ -69,7 +74,7 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}Output L2 Current"
+    name: "${nameprefix}Output L2 Current"
     register_type: holding
     address: 165
     unit_of_measurement: "A"
@@ -82,7 +87,7 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}Output L1 Power"
+    name: "${nameprefix}Output L1 Power"
     register_type: holding
     address: 173
     unit_of_measurement: "W"
@@ -94,7 +99,7 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}Output L2 Power"
+    name: "${nameprefix}Output L2 Power"
     register_type: holding
     address: 174
     unit_of_measurement: "W"
@@ -106,7 +111,7 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}Output Power"
+    name: "${nameprefix}Output Power"
     id: "${prefix}output_power"
     register_type: holding
     address: 175
@@ -119,7 +124,7 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}Output L1 Voltage"
+    name: "${nameprefix}Output L1 Voltage"
     register_type: holding
     address: 154
     unit_of_measurement: "V"
@@ -132,7 +137,7 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}Output L2 Voltage"
+    name: "${nameprefix}Output L2 Voltage"
     register_type: holding
     address: 155
     unit_of_measurement: "V"

--- a/pv_inverter/packages/deye_hybrid_1p/load.yaml
+++ b/pv_inverter/packages/deye_hybrid_1p/load.yaml
@@ -13,12 +13,13 @@
 # limitations under the License.
 
 substitutions:
-  prefix: ""
+  nameprefix: ""   # No Prefix (Single-Inverter)
+  prefix: ""       # No Prefix (Single-Inverter)
 
 sensor:
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}Load L1 Voltage"
+    name: "${nameprefix}Load L1 Voltage"
     register_type: holding
     address: 157
     unit_of_measurement: "V"
@@ -31,7 +32,7 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}Load L2 Voltage"
+    name: "${nameprefix}Load L2 Voltage"
     register_type: holding
     address: 158
     unit_of_measurement: "V"
@@ -44,7 +45,7 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}Load L1 Power"
+    name: "${nameprefix}Load L1 Power"
     register_type: holding
     address: 176
     unit_of_measurement: "W"
@@ -56,7 +57,7 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}Load L2 Power"
+    name: "${nameprefix}Load L2 Power"
     register_type: holding
     address: 177
     unit_of_measurement: "W"
@@ -68,7 +69,7 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}Load Power"
+    name: "${nameprefix}Load Power"
     register_type: holding
     address: 178
     unit_of_measurement: "W"
@@ -80,7 +81,7 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}Load L1 Current"
+    name: "${nameprefix}Load L1 Current"
     register_type: holding
     address: 179
     unit_of_measurement: "A"
@@ -93,7 +94,7 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}Load L2 Current"
+    name: "${nameprefix}Load L2 Current"
     register_type: holding
     address: 180
     unit_of_measurement: "A"
@@ -106,7 +107,7 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}Load Frequency"
+    name: "${nameprefix}Load Frequency"
     register_type: holding
     address: 192
     unit_of_measurement: "Hz"
@@ -119,7 +120,7 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}Daily Load Consumption"
+    name: "${nameprefix}Daily Load Consumption"
     id: "${prefix}daily_load_consumption"
     register_type: holding
     address: 84
@@ -134,7 +135,7 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}Total Consumption"
+    name: "${nameprefix}Total Consumption"
     id: "${prefix}total_consumption"
     register_type: holding
     address: 85
@@ -148,7 +149,7 @@ sensor:
     icon: "mdi:home-lightning-bolt"
 
   - platform: template
-    name: "${prefix}Power Losses" # Includes consumption of the inverter device itself as well AC/DC conversion losses
+    name: "${nameprefix}Power Losses" # Includes consumption of the inverter device itself as well AC/DC conversion losses
     id: "${prefix}power_losses"
     unit_of_measurement: "W"
     device_class: power
@@ -159,7 +160,7 @@ sensor:
     icon: "mdi:home-lightning-bolt"
 
   - platform: template
-    name: "${prefix}Daily Losses" # Includes today's consumption of the inverter device itself as well AC/DC conversion losses
+    name: "${nameprefix}Daily Losses" # Includes today's consumption of the inverter device itself as well AC/DC conversion losses
     id: "${prefix}daily_losses"
     unit_of_measurement: "kWh"
     device_class: energy
@@ -178,7 +179,7 @@ sensor:
     icon: "mdi:home-lightning-bolt"
 
   - platform: template
-    name: "${prefix}Total Losses" # Includes total consumption of the inverter device itself as well AC/DC conversion losses
+    name: "${nameprefix}Total Losses" # Includes total consumption of the inverter device itself as well AC/DC conversion losses
     id: "${prefix}total_losses"
     unit_of_measurement: "kWh"
     device_class: energy

--- a/pv_inverter/packages/deye_hybrid_1p/load.yaml
+++ b/pv_inverter/packages/deye_hybrid_1p/load.yaml
@@ -155,7 +155,7 @@ sensor:
     state_class: total_increasing
     accuracy_decimals: 1
     lambda: |-
-      return (id(pv1_power).state + id(pv2_power).state + id(battery_power).state - id(output_power).state);
+      return (id(${prefix}pv1_power).state + id(${prefix}pv2_power).state + id(${prefix}battery_power).state - id(${prefix}output_power).state);
     icon: "mdi:home-lightning-bolt"
 
   - platform: template
@@ -167,13 +167,13 @@ sensor:
     accuracy_decimals: 1
     lambda: |-
       return (
-        id(daily_energy_bought).state +
-        id(daily_pv_production).state +
-        id(daily_generator_production).state +
-        id(daily_battery_discharge).state -
-        id(daily_energy_sold).state -
-        id(daily_battery_charge).state -
-        id(daily_load_consumption).state
+        id(${prefix}daily_energy_bought).state +
+        id(${prefix}daily_pv_production).state +
+        id(${prefix}daily_generator_production).state +
+        id(${prefix}daily_battery_discharge).state -
+        id(${prefix}daily_energy_sold).state -
+        id(${prefix}daily_battery_charge).state -
+        id(${prefix}daily_load_consumption).state
       );
     icon: "mdi:home-lightning-bolt"
 
@@ -186,13 +186,13 @@ sensor:
     accuracy_decimals: 1
     lambda: |-
       return (
-        id(total_energy_bought).state +
-        id(total_pv_production).state +
-        id(total_generator_production).state +
-        id(total_battery_discharge).state -
-        id(total_energy_sold).state -
-        id(total_battery_charge).state -
-        id(total_consumption).state
+        id(${prefix}total_energy_bought).state +
+        id(${prefix}total_pv_production).state +
+        id(${prefix}total_generator_production).state +
+        id(${prefix}total_battery_discharge).state -
+        id(${prefix}total_energy_sold).state -
+        id(${prefix}total_battery_charge).state -
+        id(${prefix}total_consumption).state
       );
 
     icon: "mdi:home-lightning-bolt"

--- a/pv_inverter/packages/deye_hybrid_1p/load.yaml
+++ b/pv_inverter/packages/deye_hybrid_1p/load.yaml
@@ -11,10 +11,14 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+substitutions:
+  prefix: ""
+
 sensor:
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "Load L1 Voltage"
+    name: "${prefix}Load L1 Voltage"
     register_type: holding
     address: 157
     unit_of_measurement: "V"
@@ -27,7 +31,7 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "Load L2 Voltage"
+    name: "${prefix}Load L2 Voltage"
     register_type: holding
     address: 158
     unit_of_measurement: "V"
@@ -40,7 +44,7 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "Load L1 Power"
+    name: "${prefix}Load L1 Power"
     register_type: holding
     address: 176
     unit_of_measurement: "W"
@@ -52,7 +56,7 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "Load L2 Power"
+    name: "${prefix}Load L2 Power"
     register_type: holding
     address: 177
     unit_of_measurement: "W"
@@ -64,7 +68,7 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "Load Power"
+    name: "${prefix}Load Power"
     register_type: holding
     address: 178
     unit_of_measurement: "W"
@@ -76,7 +80,7 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "Load L1 Current"
+    name: "${prefix}Load L1 Current"
     register_type: holding
     address: 179
     unit_of_measurement: "A"
@@ -89,7 +93,7 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "Load L2 Current"
+    name: "${prefix}Load L2 Current"
     register_type: holding
     address: 180
     unit_of_measurement: "A"
@@ -102,7 +106,7 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "Load Frequency"
+    name: "${prefix}Load Frequency"
     register_type: holding
     address: 192
     unit_of_measurement: "Hz"
@@ -115,8 +119,8 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "Daily Load Consumption"
-    id: daily_load_consumption
+    name: "${prefix}Daily Load Consumption"
+    id: "${prefix}daily_load_consumption"
     register_type: holding
     address: 84
     unit_of_measurement: "kWh"
@@ -130,8 +134,8 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "Total Consumption"
-    id: total_consumption
+    name: "${prefix}Total Consumption"
+    id: "${prefix}total_consumption"
     register_type: holding
     address: 85
     unit_of_measurement: "kWh"
@@ -144,8 +148,8 @@ sensor:
     icon: "mdi:home-lightning-bolt"
 
   - platform: template
-    name: "Power Losses" # Includes consumption of the inverter device itself as well AC/DC conversion losses
-    id: power_losses
+    name: "${prefix}Power Losses" # Includes consumption of the inverter device itself as well AC/DC conversion losses
+    id: "${prefix}power_losses"
     unit_of_measurement: "W"
     device_class: power
     state_class: total_increasing
@@ -155,8 +159,8 @@ sensor:
     icon: "mdi:home-lightning-bolt"
 
   - platform: template
-    name: "Daily Losses" # Includes today's consumption of the inverter device itself as well AC/DC conversion losses
-    id: daily_losses
+    name: "${prefix}Daily Losses" # Includes today's consumption of the inverter device itself as well AC/DC conversion losses
+    id: "${prefix}daily_losses"
     unit_of_measurement: "kWh"
     device_class: energy
     state_class: total_increasing
@@ -174,8 +178,8 @@ sensor:
     icon: "mdi:home-lightning-bolt"
 
   - platform: template
-    name: "Total Losses" # Includes total consumption of the inverter device itself as well AC/DC conversion losses
-    id: total_losses
+    name: "${prefix}Total Losses" # Includes total consumption of the inverter device itself as well AC/DC conversion losses
+    id: "${prefix}total_losses"
     unit_of_measurement: "kWh"
     device_class: energy
     state_class: total_increasing

--- a/pv_inverter/packages/deye_hybrid_1p/modbus_master.yaml
+++ b/pv_inverter/packages/deye_hybrid_1p/modbus_master.yaml
@@ -19,9 +19,12 @@
 substitutions:
   prefix: ""
 
-  uart_tx_pin_master: GPIO17
-  uart_rx_pin_master: GPIO04
-  uart_flow_control_pin_master: GPIO16
+#  uart_rx_pin_master: "GPIO16"
+#  uart_tx_pin_master: "GPIO17"
+
+  uart_tx_pin_master: "GPIO17"
+  uart_rx_pin_master: "GPIO04"
+  uart_flow_control_pin_master: "GPIO16"
 
   uart_tx_pin_slave: GPIO17
   uart_rx_pin_slave: GPIO04

--- a/pv_inverter/packages/deye_hybrid_1p/modbus_master.yaml
+++ b/pv_inverter/packages/deye_hybrid_1p/modbus_master.yaml
@@ -22,6 +22,10 @@ substitutions:
   nameprefix: ""   # No Prefix (Single-Inverter)
   prefix: ""       # No Prefix (Single-Inverter)
 
+  uart_tx_pin_slave: "GPIO26"
+  uart_rx_pin_slave: "GPIO35"
+  uart_flow_control_pin_slave: "GPIO25"
+
 modbus:
   - id: modbus_1
     uart_id: modbus_uart_1

--- a/pv_inverter/packages/deye_hybrid_1p/modbus_master.yaml
+++ b/pv_inverter/packages/deye_hybrid_1p/modbus_master.yaml
@@ -19,17 +19,6 @@
 substitutions:
   prefix: ""
 
-#  uart_rx_pin_master: "GPIO16"
-#  uart_tx_pin_master: "GPIO17"
-
-  uart_tx_pin_master: "GPIO26"
-  uart_rx_pin_master: "GPIO35"
-  uart_flow_control_pin_master: "GPIO25"
-
-  uart_tx_pin_slave: GPIO17
-  uart_rx_pin_slave: GPIO04
-  uart_flow_control_pin_slave: GPIO16
-
 modbus:
   - id: modbus_1
     uart_id: modbus_uart_1

--- a/pv_inverter/packages/deye_hybrid_1p/modbus_master.yaml
+++ b/pv_inverter/packages/deye_hybrid_1p/modbus_master.yaml
@@ -15,6 +15,18 @@
 # modbus_master.yaml
 # This block should be loaded only in the master (or in a single inverter environment).
 # It defines BOTH Modbus-Hubs and the UARTs.
+
+substitutions:
+  prefix: ""
+
+  uart_tx_pin_master: GPIO17
+  uart_rx_pin_master: GPIO04
+  uart_flow_control_pin_master: GPIO16
+
+  uart_tx_pin_slave: GPIO17
+  uart_rx_pin_slave: GPIO04
+  uart_flow_control_pin_slave: GPIO16
+
 modbus:
   - id: modbus_1
     uart_id: modbus_uart_1
@@ -25,6 +37,7 @@ uart:
   - id: modbus_uart_1
     tx_pin: ${uart_tx_pin_master}
     rx_pin: ${uart_rx_pin_master}
+    flow_control_pin: ${uart_flow_control_pin_master}
     baud_rate: 9600
     stop_bits: 1
     data_bits: 8
@@ -32,6 +45,7 @@ uart:
   - id: modbus_uart_2
     tx_pin: ${uart_tx_pin_slave}
     rx_pin: ${uart_rx_pin_slave}
+    flow_control_pin: ${uart_flow_control_pin_slave}
     baud_rate: 9600
     stop_bits: 1
     data_bits: 8

--- a/pv_inverter/packages/deye_hybrid_1p/modbus_master.yaml
+++ b/pv_inverter/packages/deye_hybrid_1p/modbus_master.yaml
@@ -22,10 +22,6 @@ substitutions:
   nameprefix: ""   # No Prefix (Single-Inverter)
   prefix: ""       # No Prefix (Single-Inverter)
 
-  uart_tx_pin_slave: "GPIO26"
-  uart_rx_pin_slave: "GPIO35"
-  uart_flow_control_pin_slave: "GPIO25"
-
 modbus:
   - id: modbus_1
     uart_id: modbus_uart_1

--- a/pv_inverter/packages/deye_hybrid_1p/modbus_master.yaml
+++ b/pv_inverter/packages/deye_hybrid_1p/modbus_master.yaml
@@ -22,9 +22,9 @@ substitutions:
   nameprefix: ""   # No Prefix (Single-Inverter)
   prefix: ""       # No Prefix (Single-Inverter)
 
-  uart_tx_pin_slave: "GPIO26"
-  uart_rx_pin_slave: "GPIO35"
-  uart_flow_control_pin_slave: "GPIO25"
+  uart_tx_pin_slave: "GPIO17"
+  uart_rx_pin_slave: "GPIO04"
+  uart_flow_control_pin_slave: "GPIO16"
 
 modbus:
   - id: modbus_1

--- a/pv_inverter/packages/deye_hybrid_1p/modbus_master.yaml
+++ b/pv_inverter/packages/deye_hybrid_1p/modbus_master.yaml
@@ -1,0 +1,38 @@
+# Copyright 2025 Lewa-Reka & Harvey Dent
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# modbus_master.yaml
+# This block should be loaded only in the master (or in a single inverter environment).
+# It defines BOTH Modbus-Hubs and the UARTs.
+modbus:
+  - id: modbus_1
+    uart_id: modbus_uart_1
+  - id: modbus_2
+    uart_id: modbus_uart_2
+
+uart:
+  - id: modbus_uart_1
+    tx_pin: ${uart_tx_pin_master}
+    rx_pin: ${uart_rx_pin_master}
+    baud_rate: 9600
+    stop_bits: 1
+    data_bits: 8
+    parity: NONE
+  - id: modbus_uart_2
+    tx_pin: ${uart_tx_pin_slave}
+    rx_pin: ${uart_rx_pin_slave}
+    baud_rate: 9600
+    stop_bits: 1
+    data_bits: 8
+    parity: NONE

--- a/pv_inverter/packages/deye_hybrid_1p/modbus_master.yaml
+++ b/pv_inverter/packages/deye_hybrid_1p/modbus_master.yaml
@@ -1,5 +1,7 @@
 # Copyright 2025 Lewa-Reka & Harvey Dent
 #
+# Modifications and new file Copyright 2026 JHopmann
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -17,7 +19,8 @@
 # It defines BOTH Modbus-Hubs and the UARTs.
 
 substitutions:
-  prefix: ""
+  nameprefix: ""   # No Prefix (Single-Inverter)
+  prefix: ""       # No Prefix (Single-Inverter)
 
 modbus:
   - id: modbus_1

--- a/pv_inverter/packages/deye_hybrid_1p/modbus_master.yaml
+++ b/pv_inverter/packages/deye_hybrid_1p/modbus_master.yaml
@@ -22,9 +22,9 @@ substitutions:
 #  uart_rx_pin_master: "GPIO16"
 #  uart_tx_pin_master: "GPIO17"
 
-  uart_tx_pin_master: "GPIO17"
-  uart_rx_pin_master: "GPIO04"
-  uart_flow_control_pin_master: "GPIO16"
+  uart_tx_pin_master: "GPIO26"
+  uart_rx_pin_master: "GPIO35"
+  uart_flow_control_pin_master: "GPIO25"
 
   uart_tx_pin_slave: GPIO17
   uart_rx_pin_slave: GPIO04

--- a/pv_inverter/packages/deye_hybrid_1p/modbus_master.yaml
+++ b/pv_inverter/packages/deye_hybrid_1p/modbus_master.yaml
@@ -22,8 +22,12 @@ substitutions:
 modbus:
   - id: modbus_1
     uart_id: modbus_uart_1
+    #turnaround_time: 250ms    # since 2026.8.0
+    send_wait_time: 250ms      # will be removed when turnaround_time is well established in 2027.2.0
   - id: modbus_2
     uart_id: modbus_uart_2
+    #turnaround_time: 250ms    # since 2026.8.0
+    send_wait_time: 250ms      # will be removed when turnaround_time is well established in 2027.2.0
 
 uart:
   - id: modbus_uart_1

--- a/pv_inverter/packages/deye_hybrid_1p/modbus_slave.yaml
+++ b/pv_inverter/packages/deye_hybrid_1p/modbus_slave.yaml
@@ -1,5 +1,7 @@
 # Copyright 2025 Lewa-Reka & Harvey Dent
 #
+# Modifications and new file Copyright 2026 JHopmann
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -12,5 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# modbus_slave.yaml
-# This fille is intentionally empty because only the master is allowed to define Modbus-Hubs and the UARTs.
+# modbus_master.yaml
+# This block should be loaded only in the master (or in a single inverter environment).
+# It defines BOTH Modbus-Hubs and the UARTs.

--- a/pv_inverter/packages/deye_hybrid_1p/modbus_slave.yaml
+++ b/pv_inverter/packages/deye_hybrid_1p/modbus_slave.yaml
@@ -1,0 +1,16 @@
+# Copyright 2025 Lewa-Reka & Harvey Dent
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# modbus_slave.yaml
+# This fille is intentionally empty because only the master is allowed to define Modbus-Hubs and the UARTs.

--- a/pv_inverter/packages/deye_hybrid_1p/pv.yaml
+++ b/pv_inverter/packages/deye_hybrid_1p/pv.yaml
@@ -14,8 +14,8 @@
 sensor:
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "PV1 Power"
-    id: pv1_power
+    name: "${prefix}PV1 Power"
+    id: "${prefix}pv1_power"
     register_type: holding
     address: 186
     unit_of_measurement: "W"
@@ -27,8 +27,8 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "PV2 Power"
-    id: pv2_power
+    name: "${prefix}PV2 Power"
+    id: "${prefix}pv2_power"
     register_type: holding
     address: 187
     unit_of_measurement: "W"
@@ -40,8 +40,8 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "PV3 Power"
-    id: pv3_power
+    name: "${prefix}PV3 Power"
+    id: "${prefix}pv3_power"
     register_type: holding
     address: 188
     unit_of_measurement: "W"
@@ -53,8 +53,8 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "PV4 Power"
-    id: pv4_power
+    name: "${prefix}PV4 Power"
+    id: "${prefix}pv4_power"
     register_type: holding
     address: 189
     unit_of_measurement: "W"
@@ -65,9 +65,9 @@ sensor:
     icon: "mdi:solar-power-variant"
 
   - platform: template
-    name: "PV Power"
+    name: "${prefix}PV Power"
     unit_of_measurement: "W"
-    id: pv_power
+    id: "${prefix}pv_power"
     device_class: power
     state_class: "measurement"
     accuracy_decimals: 0
@@ -82,7 +82,7 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "PV1 Voltage"
+    name: "${prefix}PV1 Voltage"
     register_type: holding
     address: 109
     unit_of_measurement: "V"
@@ -95,7 +95,7 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "PV1 Current"
+    name: "${prefix}PV1 Current"
     register_type: holding
     address: 110
     unit_of_measurement: "A"
@@ -108,7 +108,7 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "PV2 Voltage"
+    name: "${prefix}PV2 Voltage"
     register_type: holding
     address: 111
     unit_of_measurement: "V"
@@ -121,7 +121,7 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "PV2 Current"
+    name: "${prefix}PV2 Current"
     register_type: holding
     address: 112
     unit_of_measurement: "A"
@@ -134,7 +134,7 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "PV3 Voltage"
+    name: "${prefix}PV3 Voltage"
     register_type: holding
     address: 113
     unit_of_measurement: "V"
@@ -147,7 +147,7 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "PV3 Current"
+    name: "${prefix}PV3 Current"
     register_type: holding
     address: 114
     unit_of_measurement: "A"
@@ -160,7 +160,7 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "PV4 Voltage"
+    name: "${prefix}PV4 Voltage"
     register_type: holding
     address: 115
     unit_of_measurement: "V"
@@ -173,7 +173,7 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "PV4 Current"
+    name: "${prefix}PV4 Current"
     register_type: holding
     address: 116
     unit_of_measurement: "A"
@@ -186,8 +186,8 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "Daily PV Production"
-    id: daily_pv_production
+    name: "${prefix}Daily PV Production"
+    id: "${prefix}daily_pv_production"
     register_type: holding
     address: 108
     unit_of_measurement: "kWh"
@@ -201,8 +201,8 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "Total PV Production"
-    id: total_pv_production
+    name: "${prefix}Total PV Production"
+    id: "${prefix}total_pv_production"
     register_type: holding
     address: 96
     unit_of_measurement: "kWh"

--- a/pv_inverter/packages/deye_hybrid_1p/pv.yaml
+++ b/pv_inverter/packages/deye_hybrid_1p/pv.yaml
@@ -11,10 +11,15 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+substitutions:
+  nameprefix: ""   # No Prefix (Single-Inverter)
+  prefix: ""       # No Prefix (Single-Inverter)
+  
 sensor:
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}PV1 Power"
+    name: "${nameprefix}PV1 Power"
     id: "${prefix}pv1_power"
     register_type: holding
     address: 186
@@ -27,7 +32,7 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}PV2 Power"
+    name: "${nameprefix}PV2 Power"
     id: "${prefix}pv2_power"
     register_type: holding
     address: 187
@@ -40,7 +45,7 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}PV3 Power"
+    name: "${nameprefix}PV3 Power"
     id: "${prefix}pv3_power"
     register_type: holding
     address: 188
@@ -53,7 +58,7 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}PV4 Power"
+    name: "${nameprefix}PV4 Power"
     id: "${prefix}pv4_power"
     register_type: holding
     address: 189
@@ -65,7 +70,7 @@ sensor:
     icon: "mdi:solar-power-variant"
 
   - platform: template
-    name: "${prefix}PV Power"
+    name: "${nameprefix}PV Power"
     unit_of_measurement: "W"
     id: "${prefix}pv_power"
     device_class: power
@@ -82,7 +87,7 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}PV1 Voltage"
+    name: "${nameprefix}PV1 Voltage"
     register_type: holding
     address: 109
     unit_of_measurement: "V"
@@ -95,7 +100,7 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}PV1 Current"
+    name: "${nameprefix}PV1 Current"
     register_type: holding
     address: 110
     unit_of_measurement: "A"
@@ -108,7 +113,7 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}PV2 Voltage"
+    name: "${nameprefix}PV2 Voltage"
     register_type: holding
     address: 111
     unit_of_measurement: "V"
@@ -121,7 +126,7 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}PV2 Current"
+    name: "${nameprefix}PV2 Current"
     register_type: holding
     address: 112
     unit_of_measurement: "A"
@@ -134,7 +139,7 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}PV3 Voltage"
+    name: "${nameprefix}PV3 Voltage"
     register_type: holding
     address: 113
     unit_of_measurement: "V"
@@ -147,7 +152,7 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}PV3 Current"
+    name: "${nameprefix}PV3 Current"
     register_type: holding
     address: 114
     unit_of_measurement: "A"
@@ -160,7 +165,7 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}PV4 Voltage"
+    name: "${nameprefix}PV4 Voltage"
     register_type: holding
     address: 115
     unit_of_measurement: "V"
@@ -173,7 +178,7 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}PV4 Current"
+    name: "${nameprefix}PV4 Current"
     register_type: holding
     address: 116
     unit_of_measurement: "A"
@@ -186,7 +191,7 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}Daily PV Production"
+    name: "${nameprefix}Daily PV Production"
     id: "${prefix}daily_pv_production"
     register_type: holding
     address: 108
@@ -201,7 +206,7 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}Total PV Production"
+    name: "${nameprefix}Total PV Production"
     id: "${prefix}total_pv_production"
     register_type: holding
     address: 96

--- a/pv_inverter/packages/deye_hybrid_1p/pv.yaml
+++ b/pv_inverter/packages/deye_hybrid_1p/pv.yaml
@@ -74,10 +74,10 @@ sensor:
     update_interval: 5s
     icon: "mdi:solar-power-variant"
     lambda: |-
-      float pv1 = isnan(id(pv1_power).state) ? 0.0 : id(pv1_power).state;
-      float pv2 = isnan(id(pv2_power).state) ? 0.0 : id(pv2_power).state;
-      float pv3 = isnan(id(pv3_power).state) ? 0.0 : id(pv3_power).state;
-      float pv4 = isnan(id(pv4_power).state) ? 0.0 : id(pv4_power).state;
+      float pv1 = isnan(id(${prefix}pv1_power).state) ? 0.0 : id(${prefix}pv1_power).state;
+      float pv2 = isnan(id(${prefix}pv2_power).state) ? 0.0 : id(${prefix}pv2_power).state;
+      float pv3 = isnan(id(${prefix}pv3_power).state) ? 0.0 : id(${prefix}pv3_power).state;
+      float pv4 = isnan(id(${prefix}pv4_power).state) ? 0.0 : id(${prefix}pv4_power).state;
       return pv1 + pv2 + pv3 +pv4;
 
   - platform: modbus_controller

--- a/pv_inverter/packages/deye_hybrid_1p/tou.yaml
+++ b/pv_inverter/packages/deye_hybrid_1p/tou.yaml
@@ -209,7 +209,7 @@ number:
   - platform: modbus_controller
     use_write_multiple: true
     name: "${prefix}Time of Use 2 Start Raw"
-    id: "time_of_use_2_start_raw"
+    id: "${prefix}time_of_use_2_start_raw"
     modbus_controller_id: ${modbus_controller_id}
     register_type: holding
     address: 251

--- a/pv_inverter/packages/deye_hybrid_1p/tou.yaml
+++ b/pv_inverter/packages/deye_hybrid_1p/tou.yaml
@@ -595,7 +595,7 @@ number:
   - platform: template
     mode: box
     name: "${prefix}Time of Use All SoC"
-    id: time_of_use_all_soc
+    id: "${prefix}time_of_use_all_soc"
     unit_of_measurement: "%"
     device_class: battery
     min_value: 0
@@ -608,20 +608,20 @@ number:
       return id(time_of_use_1_soc).state;
     set_action:
       - number.set:
-          id: time_of_use_1_soc
+          id: "${prefix}time_of_use_1_soc"
           value: !lambda "return x;"
       - number.set:
-          id: time_of_use_2_soc
+          id: "${prefix}time_of_use_2_soc"
           value: !lambda "return x;"
       - number.set:
-          id: time_of_use_3_soc
+          id: "${prefix}time_of_use_3_soc"
           value: !lambda "return x;"
       - number.set:
-          id: time_of_use_4_soc
+          id: "${prefix}time_of_use_4_soc"
           value: !lambda "return x;"
       - number.set:
-          id: time_of_use_5_soc
+          id: "${prefix}time_of_use_5_soc"
           value: !lambda "return x;"
       - number.set:
-          id: time_of_use_6_soc
+          id: "${prefix}time_of_use_6_soc"
           value: !lambda "return x;"

--- a/pv_inverter/packages/deye_hybrid_1p/tou.yaml
+++ b/pv_inverter/packages/deye_hybrid_1p/tou.yaml
@@ -4,7 +4,7 @@ substitutions:
     uint8_t minutes = raw - (hours * 100);
     return ESPTime {.minute = minutes, .hour = hours};
   func_time_to_int: "return x.hour * 100 + x.minute;"
-  prefix: ""
+  prefix: "test"
   tou_1_soc_id: "${prefix}time_of_use_1_soc" 
 
 datetime:

--- a/pv_inverter/packages/deye_hybrid_1p/tou.yaml
+++ b/pv_inverter/packages/deye_hybrid_1p/tou.yaml
@@ -2,7 +2,6 @@ substitutions:
   nameprefix: ""   # No Prefix (Single-Inverter)
   prefix: ""       # No Prefix (Single-Inverter)
 
-substitutions:
   func_int_to_time: |-
     uint8_t hours = raw / 100;
     uint8_t minutes = raw - (hours * 100);

--- a/pv_inverter/packages/deye_hybrid_1p/tou.yaml
+++ b/pv_inverter/packages/deye_hybrid_1p/tou.yaml
@@ -5,7 +5,6 @@ substitutions:
     return ESPTime {.minute = minutes, .hour = hours};
   func_time_to_int: "return x.hour * 100 + x.minute;"
   prefix: "test"
-  tou_1_soc_id: "${prefix}time_of_use_1_soctest" 
 
 datetime:
   - platform: template

--- a/pv_inverter/packages/deye_hybrid_1p/tou.yaml
+++ b/pv_inverter/packages/deye_hybrid_1p/tou.yaml
@@ -605,7 +605,7 @@ number:
     icon: "mdi:battery-clock"
     disabled_by_default: true
     lambda: |-
-      return id(${prefix}time_of_use_1_soc).state;
+      return id("${prefix}time_of_use_1_soc").state;
     set_action:
       - number.set:
           id: "${prefix}time_of_use_1_soc"

--- a/pv_inverter/packages/deye_hybrid_1p/tou.yaml
+++ b/pv_inverter/packages/deye_hybrid_1p/tou.yaml
@@ -605,7 +605,7 @@ number:
     icon: "mdi:battery-clock"
     disabled_by_default: true
     lambda: |-
-      return id(time_of_use_1_soc).state;
+      return id(${prefix}time_of_use_1_soc).state;
     set_action:
       - number.set:
           id: "${prefix}time_of_use_1_soc"

--- a/pv_inverter/packages/deye_hybrid_1p/tou.yaml
+++ b/pv_inverter/packages/deye_hybrid_1p/tou.yaml
@@ -12,7 +12,7 @@ datetime:
     type: time
     update_interval: 15s
     lambda: |-
-      auto raw = id(time_of_use_1_start_raw).state;
+      auto raw = id(${prefix}time_of_use_1_start_raw).state;
       ${func_int_to_time}
     set_action:
       - number.set:
@@ -25,7 +25,7 @@ datetime:
     type: time
     update_interval: 15s
     lambda: |-
-      auto raw = id(time_of_use_2_start_raw).state;
+      auto raw = id(${prefix}time_of_use_2_start_raw).state;
       ${func_int_to_time}
     set_action:
       - number.set:
@@ -38,7 +38,7 @@ datetime:
     type: time
     update_interval: 15s
     lambda: |-
-      auto raw = id(time_of_use_3_start_raw).state;
+      auto raw = id(${prefix}time_of_use_3_start_raw).state;
       ${func_int_to_time}
     set_action:
       - number.set:
@@ -51,7 +51,7 @@ datetime:
     type: time
     update_interval: 15s
     lambda: |-
-      auto raw = id(time_of_use_4_start_raw).state;
+      auto raw = id(${prefix}time_of_use_4_start_raw).state;
       ${func_int_to_time}
     set_action:
       - number.set:
@@ -64,7 +64,7 @@ datetime:
     type: time
     update_interval: 15s
     lambda: |-
-      auto raw = id(time_of_use_5_start_raw).state;
+      auto raw = id(${prefix}time_of_use_5_start_raw).state;
       ${func_int_to_time}
     set_action:
       - number.set:
@@ -77,7 +77,7 @@ datetime:
     type: time
     update_interval: 15s
     lambda: |-
-      auto raw = id(time_of_use_6_start_raw).state;
+      auto raw = id(${prefix}time_of_use_6_start_raw).state;
       ${func_int_to_time}
     set_action:
       - number.set:
@@ -603,7 +603,7 @@ number:
     icon: "mdi:battery-clock"
     disabled_by_default: true
     lambda: |-
-      return id(time_of_use_1_soc).state;
+      return id(${prefix}time_of_use_1_soc).state;
     set_action:
       - number.set:
           id: "${prefix}time_of_use_1_soc"

--- a/pv_inverter/packages/deye_hybrid_1p/tou.yaml
+++ b/pv_inverter/packages/deye_hybrid_1p/tou.yaml
@@ -29,7 +29,7 @@ datetime:
       ${func_int_to_time}
     set_action:
       - number.set:
-          id: "${prefix}time_of_use_2_start_raw"
+          id: "${prefix}time_of_use_2_start_rawtest2"
           value: !lambda ${func_time_to_int}
 
   - platform: template

--- a/pv_inverter/packages/deye_hybrid_1p/tou.yaml
+++ b/pv_inverter/packages/deye_hybrid_1p/tou.yaml
@@ -553,7 +553,7 @@ number:
           id: "${prefix}time_of_use_5_voltage"
           value: !lambda "return x;"
       - number.set:
-          id: "${prefix}time_of_use_6_voltage
+          id: "${prefix}time_of_use_6_voltage"
           value: !lambda "return x;"
 
   - platform: template

--- a/pv_inverter/packages/deye_hybrid_1p/tou.yaml
+++ b/pv_inverter/packages/deye_hybrid_1p/tou.yaml
@@ -608,7 +608,7 @@ number:
       return id(${tou_1_soc_id}).state; 
     set_action:
       - number.set:
-          id: "${prefix}time_of_use_1_soc"
+          id: ${tou_1_soc_id}
           value: !lambda "return x;"
       - number.set:
           id: "${prefix}time_of_use_2_soc"

--- a/pv_inverter/packages/deye_hybrid_1p/tou.yaml
+++ b/pv_inverter/packages/deye_hybrid_1p/tou.yaml
@@ -163,7 +163,7 @@ switch:
     restore_mode: DISABLED
     disabled_by_default: true
     lambda: |-
-      return id(switch_time_point_1_charge_enable).state;
+      return id(${prefix}switch_time_point_1_charge_enable).state;
     turn_on_action:
       - switch.turn_on:
           id: "${prefix}switch_time_point_1_charge_enable"

--- a/pv_inverter/packages/deye_hybrid_1p/tou.yaml
+++ b/pv_inverter/packages/deye_hybrid_1p/tou.yaml
@@ -444,7 +444,7 @@ number:
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
     name: "${prefix}Time of Use 1 SoC"
-    id: time_of_use_1_soc #id: "${tou_1_soc_id}"
+    id: "${prefix}time_of_use_1_soc" #id: "${tou_1_soc_id}"
     unit_of_measurement: "%"
     address: 268
     min_value: 0

--- a/pv_inverter/packages/deye_hybrid_1p/tou.yaml
+++ b/pv_inverter/packages/deye_hybrid_1p/tou.yaml
@@ -5,6 +5,7 @@ substitutions:
     return ESPTime {.minute = minutes, .hour = hours};
   func_time_to_int: "return x.hour * 100 + x.minute;"
   prefix: "test"
+  tou_1_soc_id: "${prefix}time_of_use_1_soctest" 
 
 datetime:
   - platform: template
@@ -591,4 +592,36 @@ number:
           id: "${prefix}time_of_use_6_out_power"
           value: !lambda "return x;"
 
-
+  - platform: template
+    mode: box
+    name: "${prefix}Time of Use All SoC"
+    id: "${prefix}time_of_use_all_soc"
+    unit_of_measurement: "%"
+    device_class: battery
+    min_value: 0
+    max_value: 100
+    step: 1
+    update_interval: 1s
+    icon: "mdi:battery-clock"
+    disabled_by_default: true
+    lambda: |-
+      return id(${tou_1_soc_id}).state; 
+    set_action:
+      - number.set:
+          id: ${tou_1_soc_id}
+          value: !lambda "return x;"
+      - number.set:
+          id: "${prefix}time_of_use_2_soc"
+          value: !lambda "return x;"
+      - number.set:
+          id: "${prefix}time_of_use_3_soc"
+          value: !lambda "return x;"
+      - number.set:
+          id: "${prefix}time_of_use_4_soc"
+          value: !lambda "return x;"
+      - number.set:
+          id: "${prefix}time_of_use_5_soc"
+          value: !lambda "return x;"
+      - number.set:
+          id: "${prefix}time_of_use_6_soc"
+          value: !lambda "return x;"

--- a/pv_inverter/packages/deye_hybrid_1p/tou.yaml
+++ b/pv_inverter/packages/deye_hybrid_1p/tou.yaml
@@ -4,14 +4,14 @@ substitutions:
     uint8_t minutes = raw - (hours * 100);
     return ESPTime {.minute = minutes, .hour = hours};
   func_time_to_int: "return x.hour * 100 + x.minute;"
-  prefix: "test"
-  #tou_1_soc_id: "${prefix}time_of_use_1_soctest" 
+  prefix: ""
+  #tou_1_soc_id: "${prefix}time_of_use_1_soc" 
 
 globals:
   - id: tou_1_soc_id
     type: int
     restore_value: yes
-    initial_value: "${prefix}time_of_use_1_soctest" 
+    initial_value: time_of_use_1_soc
 
 datetime:
   - platform: template
@@ -450,7 +450,7 @@ number:
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
     name: "${prefix}Time of Use 1 SoC"
-    id: ${tou_1_soc_id} 
+    id: "${tou_1_soc_id}"
     unit_of_measurement: "%"
     address: 268
     min_value: 0

--- a/pv_inverter/packages/deye_hybrid_1p/tou.yaml
+++ b/pv_inverter/packages/deye_hybrid_1p/tou.yaml
@@ -1,3 +1,21 @@
+# Copyright 2025 Lewa-Reka & Harvey Dent
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# modbus_master.yaml
+# This block should be loaded only in the master (or in a single inverter environment).
+# It defines BOTH Modbus-Hubs and the UARTs.
+
 substitutions:
   nameprefix: ""   # No Prefix (Single-Inverter)
   prefix: ""       # No Prefix (Single-Inverter)

--- a/pv_inverter/packages/deye_hybrid_1p/tou.yaml
+++ b/pv_inverter/packages/deye_hybrid_1p/tou.yaml
@@ -31,7 +31,7 @@ datetime:
       ${func_int_to_time}
     set_action:
       - number.set:
-          id: time_of_use_2_start_raw
+          id: ${prefix}time_of_use_2_start_raw
           value: !lambda ${func_time_to_int}
 
   - platform: template

--- a/pv_inverter/packages/deye_hybrid_1p/tou.yaml
+++ b/pv_inverter/packages/deye_hybrid_1p/tou.yaml
@@ -25,7 +25,7 @@ datetime:
     type: time
     update_interval: 15s
     lambda: |-
-      auto raw = id(${prefix}time_of_use_2_start_raw).state;
+      auto raw = id("${prefix}time_of_use_2_start_raw").state;
       ${func_int_to_time}
     set_action:
       - number.set:

--- a/pv_inverter/packages/deye_hybrid_1p/tou.yaml
+++ b/pv_inverter/packages/deye_hybrid_1p/tou.yaml
@@ -7,12 +7,6 @@ substitutions:
   prefix: ""
   #tou_1_soc_id: "${prefix}time_of_use_1_soc" 
 
-globals:
-  - id: tou_1_soc_id
-    type: int
-    restore_value: yes
-    initial_value: time_of_use_1_soc
-
 datetime:
   - platform: template
     name: "${prefix}Time of Use 1 Start"
@@ -450,7 +444,7 @@ number:
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
     name: "${prefix}Time of Use 1 SoC"
-    id: "${tou_1_soc_id}"
+    id: time_of_use_1_soc #id: "${tou_1_soc_id}"
     unit_of_measurement: "%"
     address: 268
     min_value: 0
@@ -600,8 +594,8 @@ number:
 
   - platform: template
     mode: box
-    name: "${prefix}Time of Use All SoC"
-    id: "${prefix}time_of_use_all_soc"
+    name: "Time of Use All SoC"
+    id: time_of_use_all_soc
     unit_of_measurement: "%"
     device_class: battery
     min_value: 0
@@ -611,23 +605,23 @@ number:
     icon: "mdi:battery-clock"
     disabled_by_default: true
     lambda: |-
-      return id(${tou_1_soc_id}).state; 
+      return id(time_of_use_1_soc).state;
     set_action:
       - number.set:
-          id: ${tou_1_soc_id}
+          id: time_of_use_1_soc
           value: !lambda "return x;"
       - number.set:
-          id: "${prefix}time_of_use_2_soc"
+          id: time_of_use_2_soc
           value: !lambda "return x;"
       - number.set:
-          id: "${prefix}time_of_use_3_soc"
+          id: time_of_use_3_soc
           value: !lambda "return x;"
       - number.set:
-          id: "${prefix}time_of_use_4_soc"
+          id: time_of_use_4_soc
           value: !lambda "return x;"
       - number.set:
-          id: "${prefix}time_of_use_5_soc"
+          id: time_of_use_5_soc
           value: !lambda "return x;"
       - number.set:
-          id: "${prefix}time_of_use_6_soc"
+          id: time_of_use_6_soc
           value: !lambda "return x;"

--- a/pv_inverter/packages/deye_hybrid_1p/tou.yaml
+++ b/pv_inverter/packages/deye_hybrid_1p/tou.yaml
@@ -5,7 +5,7 @@ substitutions:
     return ESPTime {.minute = minutes, .hour = hours};
   func_time_to_int: "return x.hour * 100 + x.minute;"
   prefix: ""
-
+  tou_1_soc_id: "${prefix}time_of_use_1_soc" 
 
 datetime:
   - platform: template

--- a/pv_inverter/packages/deye_hybrid_1p/tou.yaml
+++ b/pv_inverter/packages/deye_hybrid_1p/tou.yaml
@@ -594,7 +594,7 @@ number:
 
   - platform: template
     mode: box
-    name: "Time of Use All SoC"
+    name: "${prefix}Time of Use All SoC"
     id: time_of_use_all_soc
     unit_of_measurement: "%"
     device_class: battery

--- a/pv_inverter/packages/deye_hybrid_1p/tou.yaml
+++ b/pv_inverter/packages/deye_hybrid_1p/tou.yaml
@@ -1,4 +1,8 @@
 substitutions:
+  nameprefix: ""   # No Prefix (Single-Inverter)
+  prefix: ""       # No Prefix (Single-Inverter)
+
+substitutions:
   func_int_to_time: |-
     uint8_t hours = raw / 100;
     uint8_t minutes = raw - (hours * 100);
@@ -9,7 +13,7 @@ substitutions:
 
 datetime:
   - platform: template
-    name: "${prefix}Time of Use 1 Start"
+    name: "${nameprefix}Time of Use 1 Start"
     id: "${prefix}time_of_use_1_start"
     type: time
     update_interval: 15s
@@ -22,7 +26,7 @@ datetime:
           value: !lambda ${func_time_to_int}
 
   - platform: template
-    name: "${prefix}Time of Use 2 Start"
+    name: "${nameprefix}Time of Use 2 Start"
     id: "${prefix}time_of_use_2_start"
     type: time
     update_interval: 15s
@@ -35,7 +39,7 @@ datetime:
           value: !lambda ${func_time_to_int}
 
   - platform: template
-    name: "${prefix}Time of Use 3 Start"
+    name: "${nameprefix}Time of Use 3 Start"
     id: "${prefix}time_of_use_3_start"
     type: time
     update_interval: 15s
@@ -48,7 +52,7 @@ datetime:
           value: !lambda ${func_time_to_int}
 
   - platform: template
-    name: "${prefix}Time of Use 4 Start"
+    name: "${nameprefix}Time of Use 4 Start"
     id: "${prefix}time_of_use_4_start"
     type: time
     update_interval: 15s
@@ -61,7 +65,7 @@ datetime:
           value: !lambda ${func_time_to_int}
 
   - platform: template
-    name: "${prefix}Time of Use 5 Start"
+    name: "${nameprefix}Time of Use 5 Start"
     id: "${prefix}time_of_use_5_start"
     type: time
     update_interval: 15s
@@ -74,7 +78,7 @@ datetime:
           value: !lambda ${func_time_to_int}
 
   - platform: template
-    name: "${prefix}Time of Use 6 Start"
+    name: "${nameprefix}Time of Use 6 Start"
     id: "${prefix}time_of_use_6_start"
     type: time
     update_interval: 15s
@@ -90,7 +94,7 @@ switch:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}Time of Use"
+    name: "${nameprefix}Time of Use"
     id: "${prefix}switch_time_of_use"
     register_type: holding
     address: 248
@@ -100,7 +104,7 @@ switch:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}Time of Use 1 Charge Enable"
+    name: "${nameprefix}Time of Use 1 Charge Enable"
     id: "${prefix}switch_time_point_1_charge_enable"
     register_type: holding
     address: 274
@@ -110,7 +114,7 @@ switch:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}Time of Use 2 Charge Enable"
+    name: "${nameprefix}Time of Use 2 Charge Enable"
     id: "${prefix}switch_time_point_2_charge_enable"
     register_type: holding
     address: 275
@@ -120,7 +124,7 @@ switch:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}Time of Use 3 Charge Enable"
+    name: "${nameprefix}Time of Use 3 Charge Enable"
     id: "${prefix}switch_time_point_3_charge_enable"
     register_type: holding
     address: 276
@@ -130,7 +134,7 @@ switch:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}Time of Use 4 Charge Enable"
+    name: "${nameprefix}Time of Use 4 Charge Enable"
     id: "${prefix}switch_time_point_4_charge_enable"
     register_type: holding
     address: 277
@@ -140,7 +144,7 @@ switch:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}Time of Use 5 Charge Enable"
+    name: "${nameprefix}Time of Use 5 Charge Enable"
     id: "${prefix}switch_time_point_5_charge_enable"
     register_type: holding
     address: 278
@@ -150,7 +154,7 @@ switch:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}Time of Use 6 Charge Enable"
+    name: "${nameprefix}Time of Use 6 Charge Enable"
     id: "${prefix}switch_time_point_6_charge_enable"
     register_type: holding
     address: 279
@@ -158,7 +162,7 @@ switch:
     icon: "mdi:battery-plus"
 
   - platform: template
-    name: "${prefix}Time of Use All Charge Enable"
+    name: "${nameprefix}Time of Use All Charge Enable"
     id: "${prefix}switch_time_of_use_all_charge_enable"
     icon: "mdi:battery-plus"
     optimistic: true
@@ -196,7 +200,7 @@ switch:
 number:
   - platform: modbus_controller
     use_write_multiple: true
-    name: "${prefix}Time of Use 1 Start Raw"
+    name: "${nameprefix}Time of Use 1 Start Raw"
     id: "${prefix}time_of_use_1_start_raw"
     modbus_controller_id: ${modbus_controller_id}
     register_type: holding
@@ -208,7 +212,7 @@ number:
 
   - platform: modbus_controller
     use_write_multiple: true
-    name: "${prefix}Time of Use 2 Start Raw"
+    name: "${nameprefix}Time of Use 2 Start Raw"
     id: "${prefix}time_of_use_2_start_raw"
     modbus_controller_id: ${modbus_controller_id}
     register_type: holding
@@ -220,7 +224,7 @@ number:
 
   - platform: modbus_controller
     use_write_multiple: true
-    name: "${prefix}Time of Use 3 Start Raw"
+    name: "${nameprefix}Time of Use 3 Start Raw"
     id: "${prefix}time_of_use_3_start_raw"
     modbus_controller_id: ${modbus_controller_id}
     register_type: holding
@@ -232,7 +236,7 @@ number:
 
   - platform: modbus_controller
     use_write_multiple: true
-    name: "${prefix}Time of Use 4 Start Raw"
+    name: "${nameprefix}Time of Use 4 Start Raw"
     id: "${prefix}time_of_use_4_start_raw"
     modbus_controller_id: ${modbus_controller_id}
     register_type: holding
@@ -244,7 +248,7 @@ number:
 
   - platform: modbus_controller
     use_write_multiple: true
-    name: "${prefix}Time of Use 5 Start Raw"
+    name: "${nameprefix}Time of Use 5 Start Raw"
     id: "${prefix}time_of_use_5_start_raw"
     modbus_controller_id: ${modbus_controller_id}
     register_type: holding
@@ -256,7 +260,7 @@ number:
 
   - platform: modbus_controller
     use_write_multiple: true
-    name: "${prefix}Time of Use 6 Start Raw"
+    name: "${nameprefix}Time of Use 6 Start Raw"
     id: "${prefix}time_of_use_6_start_raw"
     modbus_controller_id: ${modbus_controller_id}
     register_type: holding
@@ -269,7 +273,7 @@ number:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}Time of Use 1 Voltage"
+    name: "${nameprefix}Time of Use 1 Voltage"
     id: "${prefix}time_of_use_1_voltage"
     register_type: holding
     address: 262
@@ -286,7 +290,7 @@ number:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}Time of Use 2 Voltage"
+    name: "${nameprefix}Time of Use 2 Voltage"
     id: "${prefix}time_of_use_2_voltage"
     register_type: holding
     address: 263
@@ -303,7 +307,7 @@ number:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}Time of Use 3 Voltage"
+    name: "${nameprefix}Time of Use 3 Voltage"
     id: "${prefix}time_of_use_3_voltage"
     register_type: holding
     address: 264
@@ -320,7 +324,7 @@ number:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}Time of Use 4 Voltage"
+    name: "${nameprefix}Time of Use 4 Voltage"
     id: "${prefix}time_of_use_4_voltage"
     register_type: holding
     address: 265
@@ -337,7 +341,7 @@ number:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}Time of Use 5 Voltage"
+    name: "${nameprefix}Time of Use 5 Voltage"
     id: "${prefix}time_of_use_5_voltage"
     register_type: holding
     address: 266
@@ -354,7 +358,7 @@ number:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}Time of Use 6 Voltage"
+    name: "${nameprefix}Time of Use 6 Voltage"
     id: "${prefix}time_of_use_6_voltage"
     register_type: holding
     address: 267
@@ -371,7 +375,7 @@ number:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}Time of Use 1 Out Power"
+    name: "${nameprefix}Time of Use 1 Out Power"
     id: "${prefix}time_of_use_1_out_power"
     unit_of_measurement: W
     device_class: power
@@ -383,7 +387,7 @@ number:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}Time of Use 2 Out Power"
+    name: "${nameprefix}Time of Use 2 Out Power"
     id: "${prefix}time_of_use_2_out_power"
     unit_of_measurement: W
     device_class: power
@@ -395,7 +399,7 @@ number:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}Time of Use 3 Out Power"
+    name: "${nameprefix}Time of Use 3 Out Power"
     id: "${prefix}time_of_use_3_out_power"
     unit_of_measurement: W
     device_class: power
@@ -407,7 +411,7 @@ number:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}Time of Use 4 Out Power"
+    name: "${nameprefix}Time of Use 4 Out Power"
     id: "${prefix}time_of_use_4_out_power"
     unit_of_measurement: W
     device_class: power
@@ -419,7 +423,7 @@ number:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}Time of Use 5 Out Power"
+    name: "${nameprefix}Time of Use 5 Out Power"
     id: "${prefix}time_of_use_5_out_power"
     unit_of_measurement: W
     device_class: power
@@ -431,7 +435,7 @@ number:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}Time of Use 6 Out Power"
+    name: "${nameprefix}Time of Use 6 Out Power"
     id: "${prefix}time_of_use_6_out_power"
     unit_of_measurement: W
     device_class: power
@@ -443,7 +447,7 @@ number:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}Time of Use 1 SoC"
+    name: "${nameprefix}Time of Use 1 SoC"
     id: "${prefix}time_of_use_1_soc" #id: "${tou_1_soc_id}"
     unit_of_measurement: "%"
     address: 268
@@ -457,7 +461,7 @@ number:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}Time of Use 2 SoC"
+    name: "${nameprefix}Time of Use 2 SoC"
     id: "${prefix}time_of_use_2_soc"
     unit_of_measurement: "%"
     address: 269
@@ -471,7 +475,7 @@ number:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}Time of Use 3 SoC"
+    name: "${nameprefix}Time of Use 3 SoC"
     id: "${prefix}time_of_use_3_soc"
     unit_of_measurement: "%"
     address: 270
@@ -485,7 +489,7 @@ number:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}Time of Use 4 SoC"
+    name: "${nameprefix}Time of Use 4 SoC"
     id: "${prefix}time_of_use_4_soc"
     unit_of_measurement: "%"
     address: 271
@@ -499,7 +503,7 @@ number:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}Time of Use 5 SoC"
+    name: "${nameprefix}Time of Use 5 SoC"
     id: "${prefix}time_of_use_5_soc"
     unit_of_measurement: "%"
     address: 272
@@ -513,7 +517,7 @@ number:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}Time of Use 6 SoC"
+    name: "${nameprefix}Time of Use 6 SoC"
     id: "${prefix}time_of_use_6_soc"
     unit_of_measurement: "%"
     address: 273
@@ -526,7 +530,7 @@ number:
 
   - platform: template
     mode: box
-    name: "${prefix}Time of Use All Voltage"
+    name: "${nameprefix}Time of Use All Voltage"
     id: "${prefix}time_of_use_all_voltage"
     unit_of_measurement: "V"
     device_class: voltage
@@ -560,7 +564,7 @@ number:
 
   - platform: template
     mode: box
-    name: "${prefix}Time of Use All Out Power"
+    name: "${nameprefix}Time of Use All Out Power"
     id: "${prefix}time_of_use_all_out_power"
     unit_of_measurement: W
     device_class: power
@@ -594,7 +598,7 @@ number:
 
   - platform: template
     mode: box
-    name: "${prefix}Time of Use All SoC"
+    name: "${nameprefix}Time of Use All SoC"
     id: "${prefix}time_of_use_all_soc"
     unit_of_measurement: "%"
     device_class: battery

--- a/pv_inverter/packages/deye_hybrid_1p/tou.yaml
+++ b/pv_inverter/packages/deye_hybrid_1p/tou.yaml
@@ -591,36 +591,4 @@ number:
           id: "${prefix}time_of_use_6_out_power"
           value: !lambda "return x;"
 
-  - platform: template
-    mode: box
-    name: "${prefix}Time of Use All SoC"
-    id: "${prefix}time_of_use_all_soc"
-    unit_of_measurement: "%"
-    device_class: battery
-    min_value: 0
-    max_value: 100
-    step: 1
-    update_interval: 1s
-    icon: "mdi:battery-clock"
-    disabled_by_default: true
-    lambda: |-
-      return id(${tou_1_soc_id}).state; 
-    set_action:
-      - number.set:
-          id: ${tou_1_soc_id}
-          value: !lambda "return x;"
-      - number.set:
-          id: "${prefix}time_of_use_2_soc"
-          value: !lambda "return x;"
-      - number.set:
-          id: "${prefix}time_of_use_3_soc"
-          value: !lambda "return x;"
-      - number.set:
-          id: "${prefix}time_of_use_4_soc"
-          value: !lambda "return x;"
-      - number.set:
-          id: "${prefix}time_of_use_5_soc"
-          value: !lambda "return x;"
-      - number.set:
-          id: "${prefix}time_of_use_6_soc"
-          value: !lambda "return x;"
+

--- a/pv_inverter/packages/deye_hybrid_1p/tou.yaml
+++ b/pv_inverter/packages/deye_hybrid_1p/tou.yaml
@@ -5,7 +5,13 @@ substitutions:
     return ESPTime {.minute = minutes, .hour = hours};
   func_time_to_int: "return x.hour * 100 + x.minute;"
   prefix: "test"
-  tou_1_soc_id: "${prefix}time_of_use_1_soctest" 
+  #tou_1_soc_id: "${prefix}time_of_use_1_soctest" 
+
+globals:
+  - id: tou_1_soc_id
+    type: int
+    restore_value: yes
+    initial_value: "${prefix}time_of_use_1_soctest" 
 
 datetime:
   - platform: template

--- a/pv_inverter/packages/deye_hybrid_1p/tou.yaml
+++ b/pv_inverter/packages/deye_hybrid_1p/tou.yaml
@@ -5,7 +5,7 @@ substitutions:
     return ESPTime {.minute = minutes, .hour = hours};
   func_time_to_int: "return x.hour * 100 + x.minute;"
   prefix: "test"
-  tou_1_soc_id: "${prefix}time_of_use_1_soc" 
+  tou_1_soc_id: "${prefix}time_of_use_1_soctest" 
 
 datetime:
   - platform: template

--- a/pv_inverter/packages/deye_hybrid_1p/tou.yaml
+++ b/pv_inverter/packages/deye_hybrid_1p/tou.yaml
@@ -535,7 +535,7 @@ number:
     icon: "mdi:sun-clock"
     disabled_by_default: true
     lambda: |-
-      return id(time_of_use_1_voltage).state;
+      return id(${prefix}time_of_use_1_voltage).state;
     set_action:
       - number.set:
           id: "${prefix}time_of_use_1_voltage"
@@ -569,7 +569,7 @@ number:
     icon: "mdi:power-plug"
     disabled_by_default: true
     lambda: |-
-      return id(time_of_use_1_out_power).state;
+      return id(${prefix}time_of_use_1_out_power).state;
     set_action:
       - number.set:
           id: "${prefix}time_of_use_1_out_power"

--- a/pv_inverter/packages/deye_hybrid_1p/tou.yaml
+++ b/pv_inverter/packages/deye_hybrid_1p/tou.yaml
@@ -444,7 +444,7 @@ number:
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
     name: "${prefix}Time of Use 1 SoC"
-    id: "${prefix}time_of_use_1_soc"
+    id: ${tou_1_soc_id} 
     unit_of_measurement: "%"
     address: 268
     min_value: 0
@@ -605,7 +605,7 @@ number:
     icon: "mdi:battery-clock"
     disabled_by_default: true
     lambda: |-
-      return id("${prefix}time_of_use_1_soc").state;
+      return id(${tou_1_soc_id}).state; 
     set_action:
       - number.set:
           id: "${prefix}time_of_use_1_soc"

--- a/pv_inverter/packages/deye_hybrid_1p/tou.yaml
+++ b/pv_inverter/packages/deye_hybrid_1p/tou.yaml
@@ -8,7 +8,7 @@ substitutions:
 datetime:
   - platform: template
     name: "${prefix}Time of Use 1 Start"
-    id: "${prefix}time_of_use_1_start
+    id: "${prefix}time_of_use_1_start"
     type: time
     update_interval: 15s
     lambda: |-
@@ -16,12 +16,12 @@ datetime:
       ${func_int_to_time}
     set_action:
       - number.set:
-          id: "${prefix}time_of_use_1_start_raw
+          id: "${prefix}time_of_use_1_start_raw"
           value: !lambda ${func_time_to_int}
 
   - platform: template
     name: "${prefix}Time of Use 2 Start"
-    id: "${prefix}time_of_use_2_start
+    id: "${prefix}time_of_use_2_start"
     type: time
     update_interval: 15s
     lambda: |-
@@ -29,12 +29,12 @@ datetime:
       ${func_int_to_time}
     set_action:
       - number.set:
-          id: "${prefix}time_of_use_2_start_raw
+          id: "${prefix}time_of_use_2_start_raw"
           value: !lambda ${func_time_to_int}
 
   - platform: template
     name: "${prefix}Time of Use 3 Start"
-    id: "${prefix}time_of_use_3_start
+    id: "${prefix}time_of_use_3_start"
     type: time
     update_interval: 15s
     lambda: |-
@@ -42,12 +42,12 @@ datetime:
       ${func_int_to_time}
     set_action:
       - number.set:
-          id: "${prefix}time_of_use_3_start_raw
+          id: "${prefix}time_of_use_3_start_raw"
           value: !lambda ${func_time_to_int}
 
   - platform: template
     name: "${prefix}Time of Use 4 Start"
-    id: "${prefix}time_of_use_4_start
+    id: "${prefix}time_of_use_4_start"
     type: time
     update_interval: 15s
     lambda: |-
@@ -55,12 +55,12 @@ datetime:
       ${func_int_to_time}
     set_action:
       - number.set:
-          id: "${prefix}time_of_use_4_start_raw
+          id: "${prefix}time_of_use_4_start_raw"
           value: !lambda ${func_time_to_int}
 
   - platform: template
     name: "${prefix}Time of Use 5 Start"
-    id: "${prefix}time_of_use_5_start
+    id: "${prefix}time_of_use_5_start"
     type: time
     update_interval: 15s
     lambda: |-
@@ -68,12 +68,12 @@ datetime:
       ${func_int_to_time}
     set_action:
       - number.set:
-          id: "${prefix}time_of_use_5_start_raw
+          id: "${prefix}time_of_use_5_start_raw"
           value: !lambda ${func_time_to_int}
 
   - platform: template
     name: "${prefix}Time of Use 6 Start"
-    id: "${prefix}time_of_use_6_start
+    id: "${prefix}time_of_use_6_start"
     type: time
     update_interval: 15s
     lambda: |-
@@ -81,7 +81,7 @@ datetime:
       ${func_int_to_time}
     set_action:
       - number.set:
-          id: "${prefix}time_of_use_6_start_raw
+          id: "${prefix}time_of_use_6_start_raw"
           value: !lambda ${func_time_to_int}
 
 switch:
@@ -89,7 +89,7 @@ switch:
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
     name: "${prefix}Time of Use"
-    id: "${prefix}switch_time_of_use
+    id: "${prefix}switch_time_of_use"
     register_type: holding
     address: 248
     bitmask: 1
@@ -99,7 +99,7 @@ switch:
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
     name: "${prefix}Time of Use 1 Charge Enable"
-    id: "${prefix}switch_time_point_1_charge_enable
+    id: "${prefix}switch_time_point_1_charge_enable"
     register_type: holding
     address: 274
     bitmask: 1
@@ -109,7 +109,7 @@ switch:
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
     name: "${prefix}Time of Use 2 Charge Enable"
-    id: "${prefix}switch_time_point_2_charge_enable
+    id: "${prefix}switch_time_point_2_charge_enable"
     register_type: holding
     address: 275
     bitmask: 1
@@ -119,7 +119,7 @@ switch:
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
     name: "${prefix}Time of Use 3 Charge Enable"
-    id: "${prefix}switch_time_point_3_charge_enable
+    id: "${prefix}switch_time_point_3_charge_enable"
     register_type: holding
     address: 276
     bitmask: 1
@@ -129,7 +129,7 @@ switch:
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
     name: "${prefix}Time of Use 4 Charge Enable"
-    id: "${prefix}switch_time_point_4_charge_enable
+    id: "${prefix}switch_time_point_4_charge_enable"
     register_type: holding
     address: 277
     bitmask: 1
@@ -139,7 +139,7 @@ switch:
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
     name: "${prefix}Time of Use 5 Charge Enable"
-    id: "${prefix}switch_time_point_5_charge_enable
+    id: "${prefix}switch_time_point_5_charge_enable"
     register_type: holding
     address: 278
     bitmask: 1
@@ -149,7 +149,7 @@ switch:
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
     name: "${prefix}Time of Use 6 Charge Enable"
-    id: "${prefix}switch_time_point_6_charge_enable
+    id: "${prefix}switch_time_point_6_charge_enable"
     register_type: holding
     address: 279
     bitmask: 1
@@ -157,7 +157,7 @@ switch:
 
   - platform: template
     name: "${prefix}Time of Use All Charge Enable"
-    id: "${prefix}switch_time_of_use_all_charge_enable
+    id: "${prefix}switch_time_of_use_all_charge_enable"
     icon: "mdi:battery-plus"
     optimistic: true
     restore_mode: DISABLED
@@ -166,36 +166,36 @@ switch:
       return id(switch_time_point_1_charge_enable).state;
     turn_on_action:
       - switch.turn_on:
-          id: "${prefix}switch_time_point_1_charge_enable
+          id: "${prefix}switch_time_point_1_charge_enable"
       - switch.turn_on:
-          id: "${prefix}switch_time_point_2_charge_enable
+          id: "${prefix}switch_time_point_2_charge_enable"
       - switch.turn_on:
-          id: "${prefix}switch_time_point_3_charge_enable
+          id: "${prefix}switch_time_point_3_charge_enable"
       - switch.turn_on:
-          id: "${prefix}switch_time_point_4_charge_enable
+          id: "${prefix}switch_time_point_4_charge_enable"
       - switch.turn_on:
-          id: "${prefix}switch_time_point_5_charge_enable
+          id: "${prefix}switch_time_point_5_charge_enable"
       - switch.turn_on:
-          id: "${prefix}switch_time_point_6_charge_enable
+          id: "${prefix}switch_time_point_6_charge_enable"
     turn_off_action:
       - switch.turn_off:
-          id: "${prefix}switch_time_point_1_charge_enable
+          id: "${prefix}switch_time_point_1_charge_enable"
       - switch.turn_off:
-          id: "${prefix}switch_time_point_2_charge_enable
+          id: "${prefix}switch_time_point_2_charge_enable"
       - switch.turn_off:
-          id: "${prefix}switch_time_point_3_charge_enable
+          id: "${prefix}switch_time_point_3_charge_enable"
       - switch.turn_off:
-          id: "${prefix}switch_time_point_4_charge_enable
+          id: "${prefix}switch_time_point_4_charge_enable"
       - switch.turn_off:
-          id: "${prefix}switch_time_point_5_charge_enable
+          id: "${prefix}switch_time_point_5_charge_enable"
       - switch.turn_off:
-          id: "${prefix}switch_time_point_6_charge_enable
+          id: "${prefix}switch_time_point_6_charge_enable"
 
 number:
   - platform: modbus_controller
     use_write_multiple: true
     name: "${prefix}Time of Use 1 Start Raw"
-    id: "${prefix}time_of_use_1_start_raw
+    id: "${prefix}time_of_use_1_start_raw"
     modbus_controller_id: ${modbus_controller_id}
     register_type: holding
     address: 250
@@ -207,7 +207,7 @@ number:
   - platform: modbus_controller
     use_write_multiple: true
     name: "${prefix}Time of Use 2 Start Raw"
-    id: "${prefix}time_of_use_2_start_raw
+    id: "${prefix}time_of_use_2_start_raw"
     modbus_controller_id: ${modbus_controller_id}
     register_type: holding
     address: 251
@@ -219,7 +219,7 @@ number:
   - platform: modbus_controller
     use_write_multiple: true
     name: "${prefix}Time of Use 3 Start Raw"
-    id: "${prefix}time_of_use_3_start_raw
+    id: "${prefix}time_of_use_3_start_raw"
     modbus_controller_id: ${modbus_controller_id}
     register_type: holding
     address: 252
@@ -231,7 +231,7 @@ number:
   - platform: modbus_controller
     use_write_multiple: true
     name: "${prefix}Time of Use 4 Start Raw"
-    id: "${prefix}time_of_use_4_start_raw
+    id: "${prefix}time_of_use_4_start_raw"
     modbus_controller_id: ${modbus_controller_id}
     register_type: holding
     address: 253
@@ -243,7 +243,7 @@ number:
   - platform: modbus_controller
     use_write_multiple: true
     name: "${prefix}Time of Use 5 Start Raw"
-    id: "${prefix}time_of_use_5_start_raw
+    id: "${prefix}time_of_use_5_start_raw"
     modbus_controller_id: ${modbus_controller_id}
     register_type: holding
     address: 254
@@ -255,7 +255,7 @@ number:
   - platform: modbus_controller
     use_write_multiple: true
     name: "${prefix}Time of Use 6 Start Raw"
-    id: "${prefix}time_of_use_6_start_raw
+    id: "${prefix}time_of_use_6_start_raw"
     modbus_controller_id: ${modbus_controller_id}
     register_type: holding
     address: 255
@@ -268,7 +268,7 @@ number:
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
     name: "${prefix}Time of Use 1 Voltage"
-    id: "${prefix}time_of_use_1_voltage
+    id: "${prefix}time_of_use_1_voltage"
     register_type: holding
     address: 262
     unit_of_measurement: "V"
@@ -285,7 +285,7 @@ number:
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
     name: "${prefix}Time of Use 2 Voltage"
-    id: "${prefix}time_of_use_2_voltage
+    id: "${prefix}time_of_use_2_voltage"
     register_type: holding
     address: 263
     unit_of_measurement: "V"
@@ -302,7 +302,7 @@ number:
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
     name: "${prefix}Time of Use 3 Voltage"
-    id: "${prefix}time_of_use_3_voltage
+    id: "${prefix}time_of_use_3_voltage"
     register_type: holding
     address: 264
     unit_of_measurement: "V"
@@ -319,7 +319,7 @@ number:
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
     name: "${prefix}Time of Use 4 Voltage"
-    id: "${prefix}time_of_use_4_voltage
+    id: "${prefix}time_of_use_4_voltage"
     register_type: holding
     address: 265
     unit_of_measurement: "V"
@@ -336,7 +336,7 @@ number:
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
     name: "${prefix}Time of Use 5 Voltage"
-    id: "${prefix}time_of_use_5_voltage
+    id: "${prefix}time_of_use_5_voltage"
     register_type: holding
     address: 266
     unit_of_measurement: "V"
@@ -353,7 +353,7 @@ number:
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
     name: "${prefix}Time of Use 6 Voltage"
-    id: "${prefix}time_of_use_6_voltage
+    id: "${prefix}time_of_use_6_voltage"
     register_type: holding
     address: 267
     unit_of_measurement: "V"
@@ -370,7 +370,7 @@ number:
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
     name: "${prefix}Time of Use 1 Out Power"
-    id: "${prefix}time_of_use_1_out_power
+    id: "${prefix}time_of_use_1_out_power"
     unit_of_measurement: W
     device_class: power
     address: 256
@@ -484,7 +484,7 @@ number:
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
     name: "${prefix}Time of Use 4 SoC"
-    id: "${prefix}time_of_use_4_soc
+    id: "${prefix}time_of_use_4_soc"
     unit_of_measurement: "%"
     address: 271
     min_value: 0
@@ -498,7 +498,7 @@ number:
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
     name: "${prefix}Time of Use 5 SoC"
-    id: "${prefix}time_of_use_5_soc
+    id: "${prefix}time_of_use_5_soc"
     unit_of_measurement: "%"
     address: 272
     min_value: 0
@@ -512,7 +512,7 @@ number:
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
     name: "${prefix}Time of Use 6 SoC"
-    id: "${prefix}time_of_use_6_soc
+    id: "${prefix}time_of_use_6_soc"
     unit_of_measurement: "%"
     address: 273
     min_value: 0
@@ -525,7 +525,7 @@ number:
   - platform: template
     mode: box
     name: "${prefix}Time of Use All Voltage"
-    id: "${prefix}time_of_use_all_voltage
+    id: "${prefix}time_of_use_all_voltage"
     unit_of_measurement: "V"
     device_class: voltage
     min_value: 0

--- a/pv_inverter/packages/deye_hybrid_1p/tou.yaml
+++ b/pv_inverter/packages/deye_hybrid_1p/tou.yaml
@@ -25,7 +25,7 @@ datetime:
     type: time
     update_interval: 15s
     lambda: |-
-      auto raw = id("${prefix}time_of_use_2_start_raw").state;
+      auto raw = id("${prefix}time_of_use_2_start_rawtest").state;
       ${func_int_to_time}
     set_action:
       - number.set:

--- a/pv_inverter/packages/deye_hybrid_1p/tou.yaml
+++ b/pv_inverter/packages/deye_hybrid_1p/tou.yaml
@@ -7,8 +7,6 @@ substitutions:
     uint8_t minutes = raw - (hours * 100);
     return ESPTime {.minute = minutes, .hour = hours};
   func_time_to_int: "return x.hour * 100 + x.minute;"
-  prefix: ""
-  #tou_1_soc_id: "${prefix}time_of_use_1_soc" 
 
 datetime:
   - platform: template

--- a/pv_inverter/packages/deye_hybrid_1p/tou.yaml
+++ b/pv_inverter/packages/deye_hybrid_1p/tou.yaml
@@ -25,11 +25,11 @@ datetime:
     type: time
     update_interval: 15s
     lambda: |-
-      auto raw = id("${prefix}time_of_use_2_start_rawtest").state;
+      auto raw = id(${prefix}time_of_use_2_start_raw).state;
       ${func_int_to_time}
     set_action:
       - number.set:
-          id: "${prefix}time_of_use_2_start_rawtest2"
+          id: ${prefix}time_of_use_2_start_raw
           value: !lambda ${func_time_to_int}
 
   - platform: template

--- a/pv_inverter/packages/deye_hybrid_1p/tou.yaml
+++ b/pv_inverter/packages/deye_hybrid_1p/tou.yaml
@@ -7,8 +7,8 @@ substitutions:
 
 datetime:
   - platform: template
-    name: "Time of Use 1 Start"
-    id: time_of_use_1_start
+    name: "${prefix}Time of Use 1 Start"
+    id: "${prefix}time_of_use_1_start
     type: time
     update_interval: 15s
     lambda: |-
@@ -16,12 +16,12 @@ datetime:
       ${func_int_to_time}
     set_action:
       - number.set:
-          id: time_of_use_1_start_raw
+          id: "${prefix}time_of_use_1_start_raw
           value: !lambda ${func_time_to_int}
 
   - platform: template
-    name: "Time of Use 2 Start"
-    id: time_of_use_2_start
+    name: "${prefix}Time of Use 2 Start"
+    id: "${prefix}time_of_use_2_start
     type: time
     update_interval: 15s
     lambda: |-
@@ -29,12 +29,12 @@ datetime:
       ${func_int_to_time}
     set_action:
       - number.set:
-          id: time_of_use_2_start_raw
+          id: "${prefix}time_of_use_2_start_raw
           value: !lambda ${func_time_to_int}
 
   - platform: template
-    name: "Time of Use 3 Start"
-    id: time_of_use_3_start
+    name: "${prefix}Time of Use 3 Start"
+    id: "${prefix}time_of_use_3_start
     type: time
     update_interval: 15s
     lambda: |-
@@ -42,12 +42,12 @@ datetime:
       ${func_int_to_time}
     set_action:
       - number.set:
-          id: time_of_use_3_start_raw
+          id: "${prefix}time_of_use_3_start_raw
           value: !lambda ${func_time_to_int}
 
   - platform: template
-    name: "Time of Use 4 Start"
-    id: time_of_use_4_start
+    name: "${prefix}Time of Use 4 Start"
+    id: "${prefix}time_of_use_4_start
     type: time
     update_interval: 15s
     lambda: |-
@@ -55,12 +55,12 @@ datetime:
       ${func_int_to_time}
     set_action:
       - number.set:
-          id: time_of_use_4_start_raw
+          id: "${prefix}time_of_use_4_start_raw
           value: !lambda ${func_time_to_int}
 
   - platform: template
-    name: "Time of Use 5 Start"
-    id: time_of_use_5_start
+    name: "${prefix}Time of Use 5 Start"
+    id: "${prefix}time_of_use_5_start
     type: time
     update_interval: 15s
     lambda: |-
@@ -68,12 +68,12 @@ datetime:
       ${func_int_to_time}
     set_action:
       - number.set:
-          id: time_of_use_5_start_raw
+          id: "${prefix}time_of_use_5_start_raw
           value: !lambda ${func_time_to_int}
 
   - platform: template
-    name: "Time of Use 6 Start"
-    id: time_of_use_6_start
+    name: "${prefix}Time of Use 6 Start"
+    id: "${prefix}time_of_use_6_start
     type: time
     update_interval: 15s
     lambda: |-
@@ -81,15 +81,15 @@ datetime:
       ${func_int_to_time}
     set_action:
       - number.set:
-          id: time_of_use_6_start_raw
+          id: "${prefix}time_of_use_6_start_raw
           value: !lambda ${func_time_to_int}
 
 switch:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "Time of Use"
-    id: switch_time_of_use
+    name: "${prefix}Time of Use"
+    id: "${prefix}switch_time_of_use
     register_type: holding
     address: 248
     bitmask: 1
@@ -98,8 +98,8 @@ switch:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "Time of Use 1 Charge Enable"
-    id: switch_time_point_1_charge_enable
+    name: "${prefix}Time of Use 1 Charge Enable"
+    id: "${prefix}switch_time_point_1_charge_enable
     register_type: holding
     address: 274
     bitmask: 1
@@ -108,8 +108,8 @@ switch:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "Time of Use 2 Charge Enable"
-    id: switch_time_point_2_charge_enable
+    name: "${prefix}Time of Use 2 Charge Enable"
+    id: "${prefix}switch_time_point_2_charge_enable
     register_type: holding
     address: 275
     bitmask: 1
@@ -118,8 +118,8 @@ switch:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "Time of Use 3 Charge Enable"
-    id: switch_time_point_3_charge_enable
+    name: "${prefix}Time of Use 3 Charge Enable"
+    id: "${prefix}switch_time_point_3_charge_enable
     register_type: holding
     address: 276
     bitmask: 1
@@ -128,8 +128,8 @@ switch:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "Time of Use 4 Charge Enable"
-    id: switch_time_point_4_charge_enable
+    name: "${prefix}Time of Use 4 Charge Enable"
+    id: "${prefix}switch_time_point_4_charge_enable
     register_type: holding
     address: 277
     bitmask: 1
@@ -138,8 +138,8 @@ switch:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "Time of Use 5 Charge Enable"
-    id: switch_time_point_5_charge_enable
+    name: "${prefix}Time of Use 5 Charge Enable"
+    id: "${prefix}switch_time_point_5_charge_enable
     register_type: holding
     address: 278
     bitmask: 1
@@ -148,16 +148,16 @@ switch:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "Time of Use 6 Charge Enable"
-    id: switch_time_point_6_charge_enable
+    name: "${prefix}Time of Use 6 Charge Enable"
+    id: "${prefix}switch_time_point_6_charge_enable
     register_type: holding
     address: 279
     bitmask: 1
     icon: "mdi:battery-plus"
 
   - platform: template
-    name: "Time of Use All Charge Enable"
-    id: switch_time_of_use_all_charge_enable
+    name: "${prefix}Time of Use All Charge Enable"
+    id: "${prefix}switch_time_of_use_all_charge_enable
     icon: "mdi:battery-plus"
     optimistic: true
     restore_mode: DISABLED
@@ -166,36 +166,36 @@ switch:
       return id(switch_time_point_1_charge_enable).state;
     turn_on_action:
       - switch.turn_on:
-          id: switch_time_point_1_charge_enable
+          id: "${prefix}switch_time_point_1_charge_enable
       - switch.turn_on:
-          id: switch_time_point_2_charge_enable
+          id: "${prefix}switch_time_point_2_charge_enable
       - switch.turn_on:
-          id: switch_time_point_3_charge_enable
+          id: "${prefix}switch_time_point_3_charge_enable
       - switch.turn_on:
-          id: switch_time_point_4_charge_enable
+          id: "${prefix}switch_time_point_4_charge_enable
       - switch.turn_on:
-          id: switch_time_point_5_charge_enable
+          id: "${prefix}switch_time_point_5_charge_enable
       - switch.turn_on:
-          id: switch_time_point_6_charge_enable
+          id: "${prefix}switch_time_point_6_charge_enable
     turn_off_action:
       - switch.turn_off:
-          id: switch_time_point_1_charge_enable
+          id: "${prefix}switch_time_point_1_charge_enable
       - switch.turn_off:
-          id: switch_time_point_2_charge_enable
+          id: "${prefix}switch_time_point_2_charge_enable
       - switch.turn_off:
-          id: switch_time_point_3_charge_enable
+          id: "${prefix}switch_time_point_3_charge_enable
       - switch.turn_off:
-          id: switch_time_point_4_charge_enable
+          id: "${prefix}switch_time_point_4_charge_enable
       - switch.turn_off:
-          id: switch_time_point_5_charge_enable
+          id: "${prefix}switch_time_point_5_charge_enable
       - switch.turn_off:
-          id: switch_time_point_6_charge_enable
+          id: "${prefix}switch_time_point_6_charge_enable
 
 number:
   - platform: modbus_controller
     use_write_multiple: true
-    name: "Time of Use 1 Start Raw"
-    id: time_of_use_1_start_raw
+    name: "${prefix}Time of Use 1 Start Raw"
+    id: "${prefix}time_of_use_1_start_raw
     modbus_controller_id: ${modbus_controller_id}
     register_type: holding
     address: 250
@@ -206,8 +206,8 @@ number:
 
   - platform: modbus_controller
     use_write_multiple: true
-    name: "Time of Use 2 Start Raw"
-    id: time_of_use_2_start_raw
+    name: "${prefix}Time of Use 2 Start Raw"
+    id: "${prefix}time_of_use_2_start_raw
     modbus_controller_id: ${modbus_controller_id}
     register_type: holding
     address: 251
@@ -218,8 +218,8 @@ number:
 
   - platform: modbus_controller
     use_write_multiple: true
-    name: "Time of Use 3 Start Raw"
-    id: time_of_use_3_start_raw
+    name: "${prefix}Time of Use 3 Start Raw"
+    id: "${prefix}time_of_use_3_start_raw
     modbus_controller_id: ${modbus_controller_id}
     register_type: holding
     address: 252
@@ -230,8 +230,8 @@ number:
 
   - platform: modbus_controller
     use_write_multiple: true
-    name: "Time of Use 4 Start Raw"
-    id: time_of_use_4_start_raw
+    name: "${prefix}Time of Use 4 Start Raw"
+    id: "${prefix}time_of_use_4_start_raw
     modbus_controller_id: ${modbus_controller_id}
     register_type: holding
     address: 253
@@ -242,8 +242,8 @@ number:
 
   - platform: modbus_controller
     use_write_multiple: true
-    name: "Time of Use 5 Start Raw"
-    id: time_of_use_5_start_raw
+    name: "${prefix}Time of Use 5 Start Raw"
+    id: "${prefix}time_of_use_5_start_raw
     modbus_controller_id: ${modbus_controller_id}
     register_type: holding
     address: 254
@@ -254,8 +254,8 @@ number:
 
   - platform: modbus_controller
     use_write_multiple: true
-    name: "Time of Use 6 Start Raw"
-    id: time_of_use_6_start_raw
+    name: "${prefix}Time of Use 6 Start Raw"
+    id: "${prefix}time_of_use_6_start_raw
     modbus_controller_id: ${modbus_controller_id}
     register_type: holding
     address: 255
@@ -267,8 +267,8 @@ number:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "Time of Use 1 Voltage"
-    id: time_of_use_1_voltage
+    name: "${prefix}Time of Use 1 Voltage"
+    id: "${prefix}time_of_use_1_voltage
     register_type: holding
     address: 262
     unit_of_measurement: "V"
@@ -284,8 +284,8 @@ number:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "Time of Use 2 Voltage"
-    id: time_of_use_2_voltage
+    name: "${prefix}Time of Use 2 Voltage"
+    id: "${prefix}time_of_use_2_voltage
     register_type: holding
     address: 263
     unit_of_measurement: "V"
@@ -301,8 +301,8 @@ number:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "Time of Use 3 Voltage"
-    id: time_of_use_3_voltage
+    name: "${prefix}Time of Use 3 Voltage"
+    id: "${prefix}time_of_use_3_voltage
     register_type: holding
     address: 264
     unit_of_measurement: "V"
@@ -318,8 +318,8 @@ number:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "Time of Use 4 Voltage"
-    id: time_of_use_4_voltage
+    name: "${prefix}Time of Use 4 Voltage"
+    id: "${prefix}time_of_use_4_voltage
     register_type: holding
     address: 265
     unit_of_measurement: "V"
@@ -335,8 +335,8 @@ number:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "Time of Use 5 Voltage"
-    id: time_of_use_5_voltage
+    name: "${prefix}Time of Use 5 Voltage"
+    id: "${prefix}time_of_use_5_voltage
     register_type: holding
     address: 266
     unit_of_measurement: "V"
@@ -352,8 +352,8 @@ number:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "Time of Use 6 Voltage"
-    id: time_of_use_6_voltage
+    name: "${prefix}Time of Use 6 Voltage"
+    id: "${prefix}time_of_use_6_voltage
     register_type: holding
     address: 267
     unit_of_measurement: "V"
@@ -369,8 +369,8 @@ number:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "Time of Use 1 Out Power"
-    id: time_of_use_1_out_power
+    name: "${prefix}Time of Use 1 Out Power"
+    id: "${prefix}time_of_use_1_out_power
     unit_of_measurement: W
     device_class: power
     address: 256
@@ -381,8 +381,8 @@ number:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "Time of Use 2 Out Power"
-    id: time_of_use_2_out_power
+    name: "${prefix}Time of Use 2 Out Power"
+    id: "${prefix}time_of_use_2_out_power"
     unit_of_measurement: W
     device_class: power
     address: 257
@@ -393,8 +393,8 @@ number:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "Time of Use 3 Out Power"
-    id: time_of_use_3_out_power
+    name: "${prefix}Time of Use 3 Out Power"
+    id: "${prefix}time_of_use_3_out_power"
     unit_of_measurement: W
     device_class: power
     address: 258
@@ -405,8 +405,8 @@ number:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "Time of Use 4 Out Power"
-    id: time_of_use_4_out_power
+    name: "${prefix}Time of Use 4 Out Power"
+    id: "${prefix}time_of_use_4_out_power"
     unit_of_measurement: W
     device_class: power
     address: 259
@@ -417,8 +417,8 @@ number:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "Time of Use 5 Out Power"
-    id: time_of_use_5_out_power
+    name: "${prefix}Time of Use 5 Out Power"
+    id: "${prefix}time_of_use_5_out_power"
     unit_of_measurement: W
     device_class: power
     address: 260
@@ -429,8 +429,8 @@ number:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "Time of Use 6 Out Power"
-    id: time_of_use_6_out_power
+    name: "${prefix}Time of Use 6 Out Power"
+    id: "${prefix}time_of_use_6_out_power"
     unit_of_measurement: W
     device_class: power
     address: 261
@@ -441,8 +441,8 @@ number:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "Time of Use 1 SoC"
-    id: time_of_use_1_soc
+    name: "${prefix}Time of Use 1 SoC"
+    id: "${prefix}time_of_use_1_soc"
     unit_of_measurement: "%"
     address: 268
     min_value: 0
@@ -455,8 +455,8 @@ number:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "Time of Use 2 SoC"
-    id: time_of_use_2_soc
+    name: "${prefix}Time of Use 2 SoC"
+    id: "${prefix}time_of_use_2_soc"
     unit_of_measurement: "%"
     address: 269
     min_value: 0
@@ -469,8 +469,8 @@ number:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "Time of Use 3 SoC"
-    id: time_of_use_3_soc
+    name: "${prefix}Time of Use 3 SoC"
+    id: "${prefix}time_of_use_3_soc"
     unit_of_measurement: "%"
     address: 270
     min_value: 0
@@ -483,8 +483,8 @@ number:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "Time of Use 4 SoC"
-    id: time_of_use_4_soc
+    name: "${prefix}Time of Use 4 SoC"
+    id: "${prefix}time_of_use_4_soc
     unit_of_measurement: "%"
     address: 271
     min_value: 0
@@ -497,8 +497,8 @@ number:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "Time of Use 5 SoC"
-    id: time_of_use_5_soc
+    name: "${prefix}Time of Use 5 SoC"
+    id: "${prefix}time_of_use_5_soc
     unit_of_measurement: "%"
     address: 272
     min_value: 0
@@ -511,8 +511,8 @@ number:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "Time of Use 6 SoC"
-    id: time_of_use_6_soc
+    name: "${prefix}Time of Use 6 SoC"
+    id: "${prefix}time_of_use_6_soc
     unit_of_measurement: "%"
     address: 273
     min_value: 0
@@ -524,8 +524,8 @@ number:
 
   - platform: template
     mode: box
-    name: "Time of Use All Voltage"
-    id: time_of_use_all_voltage
+    name: "${prefix}Time of Use All Voltage"
+    id: "${prefix}time_of_use_all_voltage
     unit_of_measurement: "V"
     device_class: voltage
     min_value: 0
@@ -538,28 +538,28 @@ number:
       return id(time_of_use_1_voltage).state;
     set_action:
       - number.set:
-          id: time_of_use_1_voltage
+          id: "${prefix}time_of_use_1_voltage"
           value: !lambda "return x;"
       - number.set:
-          id: time_of_use_2_voltage
+          id: "${prefix}time_of_use_2_voltage"
           value: !lambda "return x;"
       - number.set:
-          id: time_of_use_3_voltage
+          id: "${prefix}time_of_use_3_voltage"
           value: !lambda "return x;"
       - number.set:
-          id: time_of_use_4_voltage
+          id: "${prefix}time_of_use_4_voltage"
           value: !lambda "return x;"
       - number.set:
-          id: time_of_use_5_voltage
+          id: "${prefix}time_of_use_5_voltage"
           value: !lambda "return x;"
       - number.set:
-          id: time_of_use_6_voltage
+          id: "${prefix}time_of_use_6_voltage
           value: !lambda "return x;"
 
   - platform: template
     mode: box
-    name: "Time of Use All Out Power"
-    id: time_of_use_all_out_power
+    name: "${prefix}Time of Use All Out Power"
+    id: "${prefix}time_of_use_all_out_power"
     unit_of_measurement: W
     device_class: power
     min_value: 0
@@ -572,28 +572,28 @@ number:
       return id(time_of_use_1_out_power).state;
     set_action:
       - number.set:
-          id: time_of_use_1_out_power
+          id: "${prefix}time_of_use_1_out_power"
           value: !lambda "return x;"
       - number.set:
-          id: time_of_use_2_out_power
+          id: "${prefix}time_of_use_2_out_power"
           value: !lambda "return x;"
       - number.set:
-          id: time_of_use_3_out_power
+          id: "${prefix}time_of_use_3_out_power"
           value: !lambda "return x;"
       - number.set:
-          id: time_of_use_4_out_power
+          id: "${prefix}time_of_use_4_out_power"
           value: !lambda "return x;"
       - number.set:
-          id: time_of_use_5_out_power
+          id: "${prefix}time_of_use_5_out_power"
           value: !lambda "return x;"
       - number.set:
-          id: time_of_use_6_out_power
+          id: "${prefix}time_of_use_6_out_power"
           value: !lambda "return x;"
 
   - platform: template
     mode: box
-    name: "Time of Use All SoC"
-    id: time_of_use_all_soc
+    name: "${prefix}Time of Use All SoC"
+    id: "${prefix}time_of_use_all_soc"
     unit_of_measurement: "%"
     device_class: battery
     min_value: 0
@@ -606,20 +606,20 @@ number:
       return id(time_of_use_1_soc).state;
     set_action:
       - number.set:
-          id: time_of_use_1_soc
+          id: "${prefix}time_of_use_1_soc"
           value: !lambda "return x;"
       - number.set:
-          id: time_of_use_2_soc
+          id: "${prefix}time_of_use_2_soc"
           value: !lambda "return x;"
       - number.set:
-          id: time_of_use_3_soc
+          id: "${prefix}time_of_use_3_soc"
           value: !lambda "return x;"
       - number.set:
-          id: time_of_use_4_soc
+          id: "${prefix}time_of_use_4_soc"
           value: !lambda "return x;"
       - number.set:
-          id: time_of_use_5_soc
+          id: "${prefix}time_of_use_5_soc"
           value: !lambda "return x;"
       - number.set:
-          id: time_of_use_6_soc
+          id: "${prefix}time_of_use_6_soc"
           value: !lambda "return x;"

--- a/pv_inverter/packages/deye_hybrid_1p/tou.yaml
+++ b/pv_inverter/packages/deye_hybrid_1p/tou.yaml
@@ -27,7 +27,7 @@ datetime:
     type: time
     update_interval: 15s
     lambda: |-
-      auto raw = id(time_of_use_2_start_raw).state;
+      auto raw = id(${prefix}time_of_use_2_start_raw).state;
       ${func_int_to_time}
     set_action:
       - number.set:

--- a/pv_inverter/packages/deye_hybrid_1p/tou.yaml
+++ b/pv_inverter/packages/deye_hybrid_1p/tou.yaml
@@ -25,11 +25,11 @@ datetime:
     type: time
     update_interval: 15s
     lambda: |-
-      auto raw = id(${prefix}time_of_use_2_start_raw).state;
+      auto raw = id(time_of_use_2_start_raw).state;
       ${func_int_to_time}
     set_action:
       - number.set:
-          id: ${prefix}time_of_use_2_start_raw
+          id: time_of_use_2_start_raw
           value: !lambda ${func_time_to_int}
 
   - platform: template

--- a/pv_inverter/packages/deye_hybrid_1p/tou.yaml
+++ b/pv_inverter/packages/deye_hybrid_1p/tou.yaml
@@ -4,6 +4,8 @@ substitutions:
     uint8_t minutes = raw - (hours * 100);
     return ESPTime {.minute = minutes, .hour = hours};
   func_time_to_int: "return x.hour * 100 + x.minute;"
+  prefix: ""
+
 
 datetime:
   - platform: template
@@ -207,7 +209,7 @@ number:
   - platform: modbus_controller
     use_write_multiple: true
     name: "${prefix}Time of Use 2 Start Raw"
-    id: "${prefix}time_of_use_2_start_raw"
+    id: "time_of_use_2_start_raw"
     modbus_controller_id: ${modbus_controller_id}
     register_type: holding
     address: 251

--- a/pv_inverter/packages/deye_hybrid_1p/work_mode.yaml
+++ b/pv_inverter/packages/deye_hybrid_1p/work_mode.yaml
@@ -1,3 +1,20 @@
+# Copyright 2025 Lewa-Reka & Harvey Dent
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# modbus_master.yaml
+# This block should be loaded only in the master (or in a single inverter environment).
+# It defines BOTH Modbus-Hubs and the UARTs.
 
 substitutions:
   nameprefix: ""   # No Prefix (Single-Inverter)

--- a/pv_inverter/packages/deye_hybrid_1p/work_mode.yaml
+++ b/pv_inverter/packages/deye_hybrid_1p/work_mode.yaml
@@ -1,9 +1,14 @@
+
+substitutions:
+  nameprefix: ""   # No Prefix (Single-Inverter)
+  prefix: ""       # No Prefix (Single-Inverter)
+
 select:
   - platform: modbus_controller
     id: "${prefix}energy_management_priority"
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}Energy Management Priority"
+    name: "${nameprefix}Energy Management Priority"
     address: 243
     value_type: U_WORD
     icon: "mdi:priority-high"
@@ -15,7 +20,7 @@ select:
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
     id: "${prefix}system_work_mode"
-    name: "${prefix}System Work Mode"
+    name: "${nameprefix}System Work Mode"
     address: 244
     value_type: U_WORD
     icon: "mdi:cog"
@@ -26,7 +31,7 @@ select:
 
 binary_sensor:
   - platform: template
-    name: "${prefix}Load Priority"
+    name: "${nameprefix}Load Priority"
     lambda: return id(${prefix}energy_management_priority).current_option() == "Load First";
     icon: "mdi:priority-high"
 
@@ -34,7 +39,7 @@ switch:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}Solar Sell"
+    name: "${nameprefix}Solar Sell"
     id: "${prefix}switch_solar_sell"
     register_type: holding
     address: 247
@@ -45,7 +50,7 @@ switch:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}Microinverter Export cut-off"
+    name: "${nameprefix}Microinverter Export cut-off"
     register_type: holding
     address: 280
     bitmask: 0
@@ -54,7 +59,7 @@ switch:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}Generator Peak Shaving Enable"
+    name: "${nameprefix}Generator Peak Shaving Enable"
     register_type: holding
     address: 280
     bitmask: 4
@@ -63,7 +68,7 @@ switch:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}Grid Peak Shaving Enable"
+    name: "${nameprefix}Grid Peak Shaving Enable"
     register_type: holding
     address: 280
     bitmask: 8
@@ -74,7 +79,7 @@ number:
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
     id: "${prefix}max_sell_power"
-    name: "${prefix}Max Sell Power"
+    name: "${nameprefix}Max Sell Power"
     unit_of_measurement: W
     device_class: power
     min_value: 0
@@ -87,7 +92,7 @@ number:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}Max Solar Power"
+    name: "${nameprefix}Max Solar Power"
     id: "${prefix}max_solar_power"
     unit_of_measurement: W
     device_class: power
@@ -101,7 +106,7 @@ number:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}Zero Export Power"
+    name: "${nameprefix}Zero Export Power"
     id: "${prefix}zero_export_power"
     address: 206
     unit_of_measurement: "W"
@@ -116,7 +121,7 @@ number:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}Generator Peak shaving"
+    name: "${nameprefix}Generator Peak shaving"
     id: "${prefix}generator_peak_shaving_power"
     register_type: holding
     address: 292
@@ -131,7 +136,7 @@ number:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "${prefix}Grid Peak Shaving Power"
+    name: "${nameprefix}Grid Peak Shaving Power"
     id: "${prefix}grid_peak_shaving_power"
     register_type: holding
     address: 293

--- a/pv_inverter/packages/deye_hybrid_1p/work_mode.yaml
+++ b/pv_inverter/packages/deye_hybrid_1p/work_mode.yaml
@@ -27,7 +27,7 @@ select:
 binary_sensor:
   - platform: template
     name: "${prefix}Load Priority"
-    lambda: return id(energy_management_priority).current_option() == "Load First";
+    lambda: return id(${prefix}energy_management_priority).current_option() == "Load First";
     icon: "mdi:priority-high"
 
 switch:

--- a/pv_inverter/packages/deye_hybrid_1p/work_mode.yaml
+++ b/pv_inverter/packages/deye_hybrid_1p/work_mode.yaml
@@ -1,9 +1,9 @@
 select:
   - platform: modbus_controller
-    id: energy_management_priority
+    id: "${prefix}energy_management_priority"
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "Energy Management Priority"
+    name: "${prefix}Energy Management Priority"
     address: 243
     value_type: U_WORD
     icon: "mdi:priority-high"
@@ -14,8 +14,8 @@ select:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    id: system_work_mode
-    name: "System Work Mode"
+    id: "${prefix}system_work_mode"
+    name: "${prefix}System Work Mode"
     address: 244
     value_type: U_WORD
     icon: "mdi:cog"
@@ -26,7 +26,7 @@ select:
 
 binary_sensor:
   - platform: template
-    name: "Load Priority"
+    name: "${prefix}Load Priority"
     lambda: return id(energy_management_priority).current_option() == "Load First";
     icon: "mdi:priority-high"
 
@@ -34,8 +34,8 @@ switch:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "Solar Sell"
-    id: switch_solar_sell
+    name: "${prefix}Solar Sell"
+    id: "${prefix}switch_solar_sell"
     register_type: holding
     address: 247
     bitmask: 1
@@ -45,7 +45,7 @@ switch:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "Microinverter Export cut-off"
+    name: "${prefix}Microinverter Export cut-off"
     register_type: holding
     address: 280
     bitmask: 0
@@ -54,7 +54,7 @@ switch:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "Generator Peak Shaving Enable"
+    name: "${prefix}Generator Peak Shaving Enable"
     register_type: holding
     address: 280
     bitmask: 4
@@ -63,7 +63,7 @@ switch:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "Grid Peak Shaving Enable"
+    name: "${prefix}Grid Peak Shaving Enable"
     register_type: holding
     address: 280
     bitmask: 8
@@ -73,8 +73,8 @@ number:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    id: max_sell_power
-    name: "Max Sell Power"
+    id: "${prefix}max_sell_power"
+    name: "${prefix}Max Sell Power"
     unit_of_measurement: W
     device_class: power
     min_value: 0
@@ -87,8 +87,8 @@ number:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "Max Solar Power"
-    id: max_solar_power
+    name: "${prefix}Max Solar Power"
+    id: "${prefix}max_solar_power"
     unit_of_measurement: W
     device_class: power
     min_value: 0
@@ -101,8 +101,8 @@ number:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "Zero Export Power"
-    id: zero_export_power
+    name: "${prefix}Zero Export Power"
+    id: "${prefix}zero_export_power"
     address: 206
     unit_of_measurement: "W"
     device_class: power
@@ -116,8 +116,8 @@ number:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "Generator Peak shaving"
-    id: generator_peak_shaving_power
+    name: "${prefix}Generator Peak shaving"
+    id: "${prefix}generator_peak_shaving_power"
     register_type: holding
     address: 292
     unit_of_measurement: "W"
@@ -131,8 +131,8 @@ number:
   - platform: modbus_controller
     use_write_multiple: true
     modbus_controller_id: ${modbus_controller_id}
-    name: "Grid Peak Shaving Power"
-    id: grid_peak_shaving_power
+    name: "${prefix}Grid Peak Shaving Power"
+    id: "${prefix}grid_peak_shaving_power"
     register_type: holding
     address: 293
     unit_of_measurement: "W"

--- a/pv_inverter/packages/init.yaml
+++ b/pv_inverter/packages/init.yaml
@@ -18,7 +18,7 @@ substitutions:
   friendly_name: "Deye Inverter"
   modbus_hub_id: "modbus_1"    # Default Master
   uart_hub_id: "modbus_uart_1" # Default Master
-  prefix: ""
+  prefix: "abc"
 
 esphome:
   name: "${name}"

--- a/pv_inverter/packages/init.yaml
+++ b/pv_inverter/packages/init.yaml
@@ -85,13 +85,7 @@ modbus_controller:
 debug:
   update_interval: 60s
 
-sensor:
-  - platform: wifi_signal_
-    name: "${prefix}ESP WiFi Signal_"
-    id: "${prefix}esp_wifi_signal_"
-    icon: mdi:wifi
-    update_interval: 60s
-    entity_category: diagnostic
+
   - platform: uptime
     name: "${prefix}ESP Uptime"
     id: "${prefix}esp_uptime"

--- a/pv_inverter/packages/init.yaml
+++ b/pv_inverter/packages/init.yaml
@@ -19,7 +19,7 @@ substitutions:
   modbus_hub_id_1: "modbus_1"    # Default Master
   modbus_hub_id_2: "modbus_2"    # Default Slave
   uart_hub_id_1: "modbus_uart_1" # Default Master
-  uart_hub_id_1: "modbus_uart_2" # Default Slave
+  uart_hub_id_2: "modbus_uart_2" # Default Slave
   prefix: ""
 
 esphome:

--- a/pv_inverter/packages/init.yaml
+++ b/pv_inverter/packages/init.yaml
@@ -83,12 +83,6 @@ debug:
   update_interval: 60s
 
 sensor:
-  - platform: wifi_signal
-    name: "${prefix}ESP WiFi Signal_"
-    id: "${prefix}esp_wifi_signal_"
-    icon: mdi:wifi
-    update_interval: 60s
-    entity_category: diagnostic
   - platform: uptime
     name: "${prefix}ESP Uptime"
     id: "${prefix}esp_uptime"

--- a/pv_inverter/packages/init.yaml
+++ b/pv_inverter/packages/init.yaml
@@ -1,4 +1,4 @@
-﻿# Copyright 2025 Lewa-Reka <lewareka.yt@gmail.com>
+# Copyright 2025 Lewa-Reka <lewareka.yt@gmail.com>
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -82,7 +82,7 @@ modbus_controller:
 debug:
   update_interval: 60s
 
-  - platform: wifi_signal
+  - platform: wifi_signal1
     name: "${prefix}ESP WiFi Signal"
     id: "${prefix}esp_wifi_signal"
     icon: mdi:wifi

--- a/pv_inverter/packages/init.yaml
+++ b/pv_inverter/packages/init.yaml
@@ -85,7 +85,12 @@ modbus_controller:
 debug:
   update_interval: 60s
 
-
+  - platform: wifi_signal
+    name: "${prefix}ESP WiFi Signal"
+    id: "${prefix}esp_wifi_signal"
+    icon: mdi:wifi
+    update_interval: 60s
+    entity_category: diagnostic
   - platform: uptime
     name: "${prefix}ESP Uptime"
     id: "${prefix}esp_uptime"

--- a/pv_inverter/packages/init.yaml
+++ b/pv_inverter/packages/init.yaml
@@ -18,7 +18,7 @@ substitutions:
   friendly_name: "Deye Inverter"
   modbus_hub_id: "modbus_1"    # Default Master
   uart_hub_id: "modbus_uart_1" # Default Master
-
+  prefix: ""
 
 esphome:
   name: "${name}"
@@ -62,15 +62,13 @@ wifi:
 captive_portal:
 
 uart:
-  id: ${uart_hub_id}          # <--- Dynamisch gemacht
+  id: ${uart_hub_id}
   baud_rate: ${baud_rate}
   stop_bits: 1
-  # HINWEIS: Füge hier KEINE festen Pins ein, die Pins definieren wir 
-  # gleich sicher und sauber in deiner Hauptdatei in Home Assistant!
 
 modbus:
-  id: ${modbus_hub_id}        # <--- Dynamisch gemacht
-  uart_id: ${uart_hub_id}     # <--- Verweist auf die dynamische UART-ID
+  id: ${modbus_hub_id}
+  uart_id: ${uart_hub_id}
 
 modbus_controller:
   - id: ${modbus_controller_id}

--- a/pv_inverter/packages/init.yaml
+++ b/pv_inverter/packages/init.yaml
@@ -14,6 +14,12 @@
 
 substitutions:
   update_interval: 5s
+  prefix: ""
+  name: "deye-inverter"
+  friendly_name: "Deye Inverter"
+  modbus_hub_id: "modbus_1" 
+  uart_hub_id: "modbus_uart_1" # Standardwert für den Master
+
 
 esphome:
   name: "${name}"
@@ -56,23 +62,29 @@ wifi:
 
 captive_portal:
 
+# ================================================================
+# In deiner packages/init.yaml (auf GitHub)
+# ================================================================
 uart:
-  id: modbus_uart
+  id: ${uart_hub_id}          # <--- Dynamisch gemacht
   baud_rate: ${baud_rate}
   stop_bits: 1
+  # HINWEIS: Füge hier KEINE festen Pins ein, die Pins definieren wir 
+  # gleich sicher und sauber in deiner Hauptdatei in Home Assistant!
 
 modbus:
-  id: modbus_1
-  uart_id: modbus_uart
+  id: ${modbus_hub_id}        # <--- Dynamisch gemacht
+  uart_id: ${uart_hub_id}     # <--- Verweist auf die dynamische UART-ID
 
 modbus_controller:
   - id: ${modbus_controller_id}
     address: ${modbus_inverter_address}
-    modbus_id: modbus_1
+    modbus_id: ${modbus_hub_id}
     setup_priority: -10
     update_interval: ${update_interval}
     command_throttle: 60ms
     offline_skip_updates: 3
+
 
 debug:
   update_interval: 60s

--- a/pv_inverter/packages/init.yaml
+++ b/pv_inverter/packages/init.yaml
@@ -17,8 +17,8 @@ substitutions:
   prefix: ""
   name: "deye-inverter"
   friendly_name: "Deye Inverter"
-  modbus_hub_id: "modbus_1" 
-  uart_hub_id: "modbus_uart_1" # Standardwert für den Master
+  modbus_hub_id: "modbus_1"    # Default Master
+  uart_hub_id: "modbus_uart_1" # Default Master
 
 
 esphome:
@@ -62,9 +62,6 @@ wifi:
 
 captive_portal:
 
-# ================================================================
-# In deiner packages/init.yaml (auf GitHub)
-# ================================================================
 uart:
   id: ${uart_hub_id}          # <--- Dynamisch gemacht
   baud_rate: ${baud_rate}
@@ -84,7 +81,6 @@ modbus_controller:
     update_interval: ${update_interval}
     command_throttle: 60ms
     offline_skip_updates: 3
-
 
 debug:
   update_interval: 60s

--- a/pv_inverter/packages/init.yaml
+++ b/pv_inverter/packages/init.yaml
@@ -1,4 +1,4 @@
-# Copyright 2025 Lewa-Reka <lewareka.yt@gmail.com>
+﻿# Copyright 2025 Lewa-Reka <lewareka.yt@gmail.com>
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -82,9 +82,10 @@ modbus_controller:
 debug:
   update_interval: 60s
 
-  - platform: wifi_signal1
-    name: "${prefix}ESP WiFi Signal"
-    id: "${prefix}esp_wifi_signal"
+sensor:
+  - platform: wifi_signal
+    name: "${prefix}ESP WiFi Signal_"
+    id: "${prefix}esp_wifi_signal_"
     icon: mdi:wifi
     update_interval: 60s
     entity_category: diagnostic

--- a/pv_inverter/packages/init.yaml
+++ b/pv_inverter/packages/init.yaml
@@ -41,15 +41,10 @@ api:
           not: api.connected
         then:
           - logger.log: "Lost connection to HomeAssistant API - Activating safe mode"
-          - script.execute: set_safe_modbus_registers
+          - script.execute: ${prefix}set_safe_modbus_registers
 
   on_client_connected:
     - logger.log: "Connection to HomeAssistant API restored"
-
-ota:
-  - platform: esphome
-    id: ota_esphome
-    password: ${ota_password}
 
 wifi:
   ssid: ${wifi_ssid}

--- a/pv_inverter/packages/init.yaml
+++ b/pv_inverter/packages/init.yaml
@@ -58,22 +58,6 @@ wifi:
 
 captive_portal:
 
-{% if prefix == 'master_' %}
-uart:
-  - id: ${uart_hub_id_1}
-    baud_rate: ${baud_rate}
-    stop_bits: 1
-  - id: ${uart_hub_id_2}
-    baud_rate: ${baud_rate}
-    stop_bits: 1
-
-modbus:
-  id: ${modbus_hub_id_1}
-  uart_id: ${uart_hub_id_1}
-  id: ${modbus_hub_id_2}
-  uart_id: ${uart_hub_id_2}
-{% endif %}
-
 modbus_controller:
   - id: ${modbus_controller_id}
     address: ${modbus_inverter_address}

--- a/pv_inverter/packages/init.yaml
+++ b/pv_inverter/packages/init.yaml
@@ -64,7 +64,7 @@ modbus_controller:
     modbus_id: ${modbus_hub_id}
     setup_priority: -10
     update_interval: ${update_interval}
-    command_throttle: 60ms
+    #command_throttle: 60ms         # deprecated since 2026.8.0
     offline_skip_updates: 3
 
 debug:

--- a/pv_inverter/packages/init.yaml
+++ b/pv_inverter/packages/init.yaml
@@ -87,37 +87,37 @@ debug:
 
 sensor:
   - platform: wifi_signal
-    name: "ESP WiFi Signal"
-    id: esp_wifi_signal
+    name: "${prefix}ESP WiFi Signal"
+    id: "${prefix}esp_wifi_signal"
     icon: mdi:wifi
     update_interval: 60s
     entity_category: diagnostic
   - platform: uptime
-    name: ESP Uptime
-    id: esp_uptime
+    name: "${prefix}ESP Uptime"
+    id: "${prefix}esp_uptime"
     type: seconds
     icon: mdi:timer-check
     update_interval: 60s
     entity_category: diagnostic
   - platform: debug
     free:
-      name: ESP Heap Free
-      id: esp_heap_free
+      name: "${prefix}ESP Heap Free"
+      id: "${prefix}esp_heap_free"
       icon: mdi:memory
       entity_category: diagnostic
     block:
-      name: ESP Heap Max Block
-      id: esp_heap_max_block
+      name: "${prefix}ESP Heap Max Block"
+      id: "${prefix}esp_heap_max_block"
       icon: mdi:memory
       entity_category: diagnostic
     loop_time:
-      name: ESP Loop Time
-      id: esp_loop_time
+      name: "${prefix}ESP Loop Time"
+      id: "${prefix}esp_loop_time"
       icon: mdi:reload
       entity_category: diagnostic
     cpu_frequency:
-      name: ESP CPU Frequency
-      id: esp_cpu_frequency
+      name: "${prefix}ESP CPU Frequency"
+      id: "${prefix}esp_cpu_frequency"
       icon: mdi:cpu-32-bit
       unit_of_measurement: "MHz"
       filters:
@@ -127,17 +127,17 @@ sensor:
 text_sensor:
   - platform: wifi_info
     ip_address:
-      name: ESP IP Address
-      id: esp_ip_address
+      name: "${prefix}ESP IP Address"
+      id: "${prefix}esp_ip_address"
       icon: mdi:ip-network
       entity_category: diagnostic
     ssid:
-      name: ESP WiFi SSID
-      id: esp_wifi_ssid
+      name: "${prefix}ESP WiFi SSID"
+      id: "${prefix}esp_wifi_ssid"
       icon: mdi:access-point
       entity_category: diagnostic
     mac_address:
-      name: ESP Mac Address
-      id: esp_mac_address
+      name: "${prefix}ESP Mac Address"
+      id: "${prefix}esp_mac_address"
       icon: mdi:expansion-card
       entity_category: diagnostic

--- a/pv_inverter/packages/init.yaml
+++ b/pv_inverter/packages/init.yaml
@@ -18,7 +18,7 @@ substitutions:
   friendly_name: "Deye Inverter"
   modbus_hub_id: "modbus_1"    # Default Master
   uart_hub_id: "modbus_uart_1" # Default Master
-  prefix: "abc"
+  prefix: ""
 
 esphome:
   name: "${name}"

--- a/pv_inverter/packages/init.yaml
+++ b/pv_inverter/packages/init.yaml
@@ -16,8 +16,10 @@ substitutions:
   update_interval: 5s
   name: "deye-inverter"
   friendly_name: "Deye Inverter"
-  modbus_hub_id: "modbus_1"    # Default Master
-  uart_hub_id: "modbus_uart_1" # Default Master
+  modbus_hub_id_1: "modbus_1"    # Default Master
+  modbus_hub_id_2: "modbus_2"    # Default Slave
+  uart_hub_id_1: "modbus_uart_1" # Default Master
+  uart_hub_id_1: "modbus_uart_2" # Default Slave
   prefix: ""
 
 esphome:
@@ -58,13 +60,18 @@ captive_portal:
 
 {% if prefix == 'master_' %}
 uart:
-  id: ${uart_hub_id}
-  baud_rate: ${baud_rate}
-  stop_bits: 1
+  - id: ${uart_hub_id_1}
+    baud_rate: ${baud_rate}
+    stop_bits: 1
+  - id: ${uart_hub_id_2}
+    baud_rate: ${baud_rate}
+    stop_bits: 1
 
 modbus:
-  id: ${modbus_hub_id}
-  uart_id: ${uart_hub_id}
+  id: ${modbus_hub_id_1}
+  uart_id: ${uart_hub_id_1}
+  id: ${modbus_hub_id_2}
+  uart_id: ${uart_hub_id_2}
 {% endif %}
 
 modbus_controller:

--- a/pv_inverter/packages/init.yaml
+++ b/pv_inverter/packages/init.yaml
@@ -56,6 +56,7 @@ wifi:
 
 captive_portal:
 
+{% if prefix == 'master_' %}
 uart:
   id: ${uart_hub_id}
   baud_rate: ${baud_rate}
@@ -64,6 +65,7 @@ uart:
 modbus:
   id: ${modbus_hub_id}
   uart_id: ${uart_hub_id}
+{% endif %}
 
 modbus_controller:
   - id: ${modbus_controller_id}

--- a/pv_inverter/packages/init.yaml
+++ b/pv_inverter/packages/init.yaml
@@ -86,9 +86,9 @@ debug:
   update_interval: 60s
 
 sensor:
-  - platform: wifi_signal
-    name: "${prefix}ESP WiFi Signal"
-    id: "${prefix}esp_wifi_signal"
+  - platform: wifi_signal_
+    name: "${prefix}ESP WiFi Signal_"
+    id: "${prefix}esp_wifi_signal_"
     icon: mdi:wifi
     update_interval: 60s
     entity_category: diagnostic

--- a/pv_inverter/packages/init.yaml
+++ b/pv_inverter/packages/init.yaml
@@ -20,7 +20,8 @@ substitutions:
   modbus_hub_id_2: "modbus_2"    # Default Slave
   uart_hub_id_1: "modbus_uart_1" # Default Master
   uart_hub_id_2: "modbus_uart_2" # Default Slave
-  prefix: ""
+  nameprefix: ""   # No Prefix (Single-Inverter)
+  prefix: ""       # No Prefix (Single-Inverter)
 
 esphome:
   name: "${name}"
@@ -56,6 +57,15 @@ wifi:
     ssid: "${friendly_name} Fallback Hotspot"
     password: ${fallback_password}
 
+# ============ WEB-SERVER ============
+web_server:
+  port: 80
+
+# ============ OTA ============
+ota:
+  - platform: esphome
+    password: ${ota_password}
+
 captive_portal:
 
 modbus_controller:
@@ -72,13 +82,13 @@ debug:
 
 sensor:
   - platform: wifi_signal
-    name: "${prefix}ESP WiFi Signal"
+    name: "${nameprefix}ESP WiFi Signal"
     id: "${prefix}esp_wifi_signal"
     icon: mdi:wifi
     update_interval: 60s
     entity_category: diagnostic
   - platform: uptime
-    name: "${prefix}ESP Uptime"
+    name: "${nameprefix}ESP Uptime"
     id: "${prefix}esp_uptime"
     type: seconds
     icon: mdi:timer-check
@@ -86,22 +96,22 @@ sensor:
     entity_category: diagnostic
   - platform: debug
     free:
-      name: "${prefix}ESP Heap Free"
+      name: "${nameprefix}ESP Heap Free"
       id: "${prefix}esp_heap_free"
       icon: mdi:memory
       entity_category: diagnostic
     block:
-      name: "${prefix}ESP Heap Max Block"
+      name: "${nameprefix}ESP Heap Max Block"
       id: "${prefix}esp_heap_max_block"
       icon: mdi:memory
       entity_category: diagnostic
     loop_time:
-      name: "${prefix}ESP Loop Time"
+      name: "${nameprefix}ESP Loop Time"
       id: "${prefix}esp_loop_time"
       icon: mdi:reload
       entity_category: diagnostic
     cpu_frequency:
-      name: "${prefix}ESP CPU Frequency"
+      name: "${nameprefix}ESP CPU Frequency"
       id: "${prefix}esp_cpu_frequency"
       icon: mdi:cpu-32-bit
       unit_of_measurement: "MHz"
@@ -112,17 +122,17 @@ sensor:
 text_sensor:
   - platform: wifi_info
     ip_address:
-      name: "${prefix}ESP IP Address"
+      name: "${nameprefix}ESP IP Address"
       id: "${prefix}esp_ip_address"
       icon: mdi:ip-network
       entity_category: diagnostic
     ssid:
-      name: "${prefix}ESP WiFi SSID"
+      name: "${nameprefix}ESP WiFi SSID"
       id: "${prefix}esp_wifi_ssid"
       icon: mdi:access-point
       entity_category: diagnostic
     mac_address:
-      name: "${prefix}ESP Mac Address"
+      name: "${nameprefix}ESP Mac Address"
       id: "${prefix}esp_mac_address"
       icon: mdi:expansion-card
       entity_category: diagnostic

--- a/pv_inverter/packages/init.yaml
+++ b/pv_inverter/packages/init.yaml
@@ -83,6 +83,12 @@ debug:
   update_interval: 60s
 
 sensor:
+  - platform: wifi_signal
+    name: "${prefix}ESP WiFi Signal"
+    id: "${prefix}esp_wifi_signal"
+    icon: mdi:wifi
+    update_interval: 60s
+    entity_category: diagnostic
   - platform: uptime
     name: "${prefix}ESP Uptime"
     id: "${prefix}esp_uptime"

--- a/pv_inverter/packages/init.yaml
+++ b/pv_inverter/packages/init.yaml
@@ -14,7 +14,6 @@
 
 substitutions:
   update_interval: 5s
-  prefix: ""
   name: "deye-inverter"
   friendly_name: "Deye Inverter"
   modbus_hub_id: "modbus_1"    # Default Master


### PR DESCRIPTION
## Description

Dear Lewa-Reka,
first of all I want to say Thank YOU! for all the work you have done with your deye-inverter-project.
On my inverters it is running fine.

Some weeks ago I have seen (in a deleted branch) you intended to make the implementation multi-inverter capable.
I have implemented these changes right now so that one can connect multiple instances from one ESP32, by preserving the functionality to connect only ONE instance.

The sensors have been changed in a way that a prefix can separate the instances:
    name: "${nameprefix}PV1 Power"
    id: "${prefix}pv1_power"
and in a single-environment simply "nothing" happens as prefix is empty "".

I had to move the definition of uart and modbus to an external file "modbus_master.yaml" as the definition of these is allowed only once. Hence the def of both, the uart and modbus has to be done in the master. 
I tested this impementation, and it also works fine in a single environment.

The pv-inverter.yaml contains now two examples of two different setups: Multi (commented) and Single (active).

I would kindly ask you to consider this implementation and test it to do a merge into your branch.

Let me know your outcome. Kindest regards Jörg Hopmann

## Changes relate to

- [ ] Docs
- [ ] Deye 3P LP
- [ ] Deye 3P HV
- [X ] Deye 1P LP
- [ ] Other
